### PR TITLE
feat: add Flash Trade perpetuals DEX skill

### DIFF
--- a/flash-trade/ApiReference.md
+++ b/flash-trade/ApiReference.md
@@ -1,0 +1,1656 @@
+# Flash Trade API Reference
+
+REST API for the Flash Trade perpetuals protocol. Built with Axum 0.8 in Rust, serving real-time on-chain account data ingested via Yellowstone gRPC and Pyth Lazer price feeds.
+
+**Base URL:** `$FLASH_API_URL` (e.g. `https://flashapi.trade`)
+
+**Swagger UI:** `$FLASH_API_URL/docs/`
+
+**OpenAPI JSON:** `$FLASH_API_URL/api-docs/openapi.json`
+
+**Authentication:** None. The API is public with no auth headers required.
+
+**WebSocket limits:** 10,000 global connections; 5 connections per owner wallet.
+
+---
+
+## Table of Contents
+
+- [Error Format](#error-format)
+- [Health](#health)
+- [Raw Accounts](#raw-accounts)
+  - [Perpetuals](#perpetuals)
+  - [Pools](#pools)
+  - [Custodies](#custodies)
+  - [Markets](#markets)
+  - [Positions (Raw)](#positions-raw)
+  - [Orders (Raw)](#orders-raw)
+- [Enriched Positions](#enriched-positions)
+- [Enriched Orders](#enriched-orders)
+- [Tokens](#tokens)
+- [Prices](#prices)
+- [Pool Data](#pool-data)
+- [Transaction Builder -- Trading](#transaction-builder----trading)
+  - [Open Position](#open-position)
+  - [Close Position](#close-position)
+  - [Reverse Position](#reverse-position)
+- [Transaction Builder -- Collateral](#transaction-builder----collateral)
+  - [Add Collateral](#add-collateral)
+  - [Remove Collateral](#remove-collateral)
+- [Transaction Builder -- Trigger Orders](#transaction-builder----trigger-orders)
+  - [Place Trigger Order](#place-trigger-order)
+  - [Edit Trigger Order](#edit-trigger-order)
+  - [Cancel Trigger Order](#cancel-trigger-order)
+  - [Cancel All Trigger Orders](#cancel-all-trigger-orders)
+- [Transaction Builder -- Account Setup](#transaction-builder----account-setup)
+  - [Init Token Stake](#init-token-stake)
+  - [Create Referral](#create-referral)
+- [Previews](#previews)
+  - [Limit Order Fees](#limit-order-fees)
+  - [Exit Fee](#exit-fee)
+  - [TP/SL Preview](#tpsl-preview)
+  - [Margin Preview](#margin-preview)
+- [WebSocket Streaming](#websocket-streaming)
+
+---
+
+## Error Format
+
+All error responses use the same JSON shape:
+
+```json
+{
+  "error": "descriptive error message"
+}
+```
+
+For transaction builder trigger-order endpoints, errors use:
+
+```json
+{
+  "err": "descriptive error message"
+}
+```
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | Success |
+| `101` | WebSocket upgrade |
+| `400` | Bad request / validation error / invalid pubkey / config error |
+| `404` | Resource not found |
+| `409` | Conflict |
+| `429` | Too many requests (per-owner WebSocket limit) |
+| `500` | Internal server error / compute error |
+| `503` | Service unavailable (price missing, global connection limit) |
+
+---
+
+## Health
+
+### `GET /health`
+
+Returns service status and cached account counts.
+
+**Response `200`:**
+
+```json
+{
+  "status": "ok",
+  "accounts": {
+    "perpetuals": 1,
+    "pools": 2,
+    "custodies": 12,
+    "markets": 10,
+    "positions": 4500,
+    "orders": 1200
+  }
+}
+```
+
+---
+
+## Raw Accounts
+
+These endpoints return raw Anchor-deserialized on-chain program account data as JSON. The response shapes mirror the on-chain Anchor IDL structs and are not documented in detail here -- see the Anchor IDL at `idls/perpetuals.json` for exact field definitions.
+
+### Perpetuals
+
+#### `GET /raw/perpetuals`
+
+Returns all perpetuals accounts.
+
+**Response `200`:**
+
+```json
+[
+  {
+    "pubkey": "FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn",
+    "account": { /* raw Anchor-deserialized perpetuals account */ }
+  }
+]
+```
+
+#### `GET /raw/perpetuals/{pubkey}`
+
+Returns a single perpetuals account.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Perpetuals account public key (base58) |
+
+**Response `200`:** Raw Anchor-deserialized perpetuals account JSON.
+
+**Response `404`:** `{ "error": "perpetuals account {pubkey} not found" }`
+
+---
+
+### Pools
+
+#### `GET /raw/pools`
+
+Returns all pool accounts.
+
+**Response `200`:**
+
+```json
+[
+  {
+    "pubkey": "2RLpwpC1X2FyMnVpwMGo9dTr8jGMfxHzU2S94MbYHBqn",
+    "account": { /* raw Anchor-deserialized pool account */ }
+  }
+]
+```
+
+#### `GET /raw/pools/{pubkey}`
+
+Returns a single pool account.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Pool account public key (base58) |
+
+**Response `200`:** Raw pool account JSON.
+
+**Response `404`:** `{ "error": "pool account {pubkey} not found" }`
+
+---
+
+### Custodies
+
+#### `GET /raw/custodies`
+
+Returns all custody accounts.
+
+**Response `200`:**
+
+```json
+[
+  {
+    "pubkey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    "account": { /* raw Anchor-deserialized custody account */ }
+  }
+]
+```
+
+#### `GET /raw/custodies/{pubkey}`
+
+Returns a single custody account.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Custody account public key (base58) |
+
+**Response `200`:** Raw custody account JSON.
+
+**Response `404`:** `{ "error": "custody account {pubkey} not found" }`
+
+---
+
+### Markets
+
+#### `GET /raw/markets`
+
+Returns all market accounts.
+
+**Response `200`:**
+
+```json
+[
+  {
+    "pubkey": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+    "account": { /* raw Anchor-deserialized market account */ }
+  }
+]
+```
+
+#### `GET /raw/markets/{pubkey}`
+
+Returns a single market account.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Market account public key (base58) |
+
+**Response `200`:** Raw market account JSON.
+
+**Response `404`:** `{ "error": "market account {pubkey} not found" }`
+
+---
+
+### Positions (Raw)
+
+#### `GET /raw/positions/{pubkey}`
+
+Returns raw Anchor-deserialized position account data.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Position account public key (base58) |
+
+**Response `200`:** Raw position account JSON.
+
+**Response `404`:** `{ "error": "position account {pubkey} not found" }`
+
+---
+
+### Orders (Raw)
+
+#### `GET /raw/orders/{pubkey}`
+
+Returns raw Anchor-deserialized order account data.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pubkey` | path | string | yes | Order account public key (base58) |
+
+**Response `200`:** Raw order account JSON.
+
+**Response `404`:** `{ "error": "order account {pubkey} not found" }`
+
+---
+
+## Enriched Positions
+
+### `GET /positions/owner/{owner}`
+
+Returns all positions for an owner wallet, enriched with PnL, leverage, and liquidation data computed from current oracle prices.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `owner` | path | string | yes | Owner wallet public key (base58) |
+| `includePnlInLeverageDisplay` | query | boolean | yes | Whether to factor PnL into the displayed leverage calculation |
+
+**Response `200`:** Array of `PositionTableDataUiDto`
+
+```json
+[
+  {
+    "key": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    "positionAccountData": "qryP5HpA99AAAAAA...",
+    "sideUi": "Long",
+    "marketSymbol": "SOL",
+    "collateralSymbol": "USDC",
+    "entryOraclePrice": {
+      "price": "14852000000",
+      "exponent": "-8",
+      "confidence": "0",
+      "timestamp": "1707900000"
+    },
+    "entryPriceUi": "148.52",
+    "sizeAmountUi": "3.37",
+    "sizeAmountUiKmb": "3.37",
+    "sizeUsdUi": "500.00",
+    "collateralAmountUi": "100.00",
+    "collateralAmountUiKmb": "100.00",
+    "collateralUsdUi": "100.00",
+    "isDegen": false,
+    "pnl": {
+      "profitUsd": "12.50",
+      "lossUsd": "0.00",
+      "exitFeeUsd": "0.40",
+      "borrowFeeUsd": "0.15",
+      "exitFeeAmount": "0.002700",
+      "borrowFeeAmount": "0.001012",
+      "priceImpactUsd": "0",
+      "priceImpactSet": false
+    },
+    "pnlWithFeeUsdUi": "11.95",
+    "pnlPercentageWithFee": "11.95",
+    "pnlWithoutFeeUsdUi": "12.50",
+    "pnlPercentageWithoutFee": "12.50",
+    "liquidationPriceUi": "120.30",
+    "leverageUi": "5.00"
+  }
+]
+```
+
+All fields except `key` and `positionAccountData` are optional (omitted when `null` via `skip_serializing_if`). They may be absent if enrichment fails (e.g. missing market config or price data).
+
+**Note on PnL values:** `pnlWithFeeUsdUi` and `pnlPercentageWithFee` are negative for losing positions (e.g., `"-15.30"` for a 15.3% loss). The `profitUsd` and `lossUsd` fields inside `pnl` are always non-negative — use `profitUsd` for gains and `lossUsd` for losses.
+
+---
+
+## Enriched Orders
+
+### `GET /orders/owner/{owner}`
+
+Returns all enriched orders for an owner wallet, including limit orders, take-profit, and stop-loss trigger orders.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `owner` | path | string | yes | Owner wallet public key (base58) |
+
+**Response `200`:** Array of `OrderDataUiDto`
+
+```json
+[
+  {
+    "key": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    "orderAccountData": "base64-encoded-raw-data...",
+    "limitOrders": [
+      {
+        "market": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+        "orderId": 0,
+        "sideUi": "Long",
+        "symbol": "SOL",
+        "reserveSymbol": "USDC",
+        "reserveAmountUi": "100.00",
+        "reserveAmountUsdUi": "100.00",
+        "sizeAmountUi": "0.67",
+        "sizeAmountUiKmb": "0.67",
+        "sizeUsdUi": "500.00",
+        "collateralAmountUi": "100.00",
+        "collateralAmountUiKmb": "100.00",
+        "collateralAmountUsdUi": "100.00",
+        "entryOraclePrice": {
+          "price": "14852000000",
+          "exponent": "-8",
+          "confidence": "0",
+          "timestamp": "1707900000"
+        },
+        "entryPriceUi": "148.52",
+        "leverageUi": "5.00",
+        "liquidationPriceUi": "120.30",
+        "limitTakeProfitPriceUi": "-",
+        "limitStopLossPriceUi": "-",
+        "receiveTokenSymbol": "USDC",
+        "reserveTokenSymbol": "USDC"
+      }
+    ],
+    "takeProfitOrders": [
+      {
+        "market": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+        "orderId": 0,
+        "sideUi": "Long",
+        "symbol": "SOL",
+        "receiveTokenSymbol": "USDC",
+        "sizeAmountUi": "0.67",
+        "sizeAmountUiKmb": "0.67",
+        "sizeUsdUi": "500.00",
+        "type": "TP",
+        "triggerPriceUi": "160.00",
+        "leverage": ""
+      }
+    ],
+    "stopLossOrders": [
+      {
+        "market": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+        "orderId": 0,
+        "sideUi": "Long",
+        "symbol": "SOL",
+        "receiveTokenSymbol": "USDC",
+        "sizeAmountUi": "0.67",
+        "sizeAmountUiKmb": "0.67",
+        "sizeUsdUi": "500.00",
+        "type": "SL",
+        "triggerPriceUi": "130.00",
+        "leverage": ""
+      }
+    ]
+  }
+]
+```
+
+---
+
+## Tokens
+
+### `GET /tokens`
+
+Returns all supported tokens from pool configuration. Deduplicated by mint address.
+
+**Response `200`:** Array of `TokenDto`
+
+```json
+[
+  {
+    "symbol": "SOL",
+    "mintKey": "So11111111111111111111111111111111111111112",
+    "decimals": 9,
+    "usdPrecision": 2,
+    "tokenPrecision": 4,
+    "isStable": false,
+    "isVirtual": false,
+    "lazerId": 7,
+    "pythTicker": "Crypto.SOL/USD",
+    "pythPriceId": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+    "isToken2022": false
+  },
+  {
+    "symbol": "USDC",
+    "mintKey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "decimals": 6,
+    "usdPrecision": 4,
+    "tokenPrecision": 2,
+    "isStable": true,
+    "isVirtual": false,
+    "lazerId": 19,
+    "pythTicker": "Crypto.USDC/USD",
+    "pythPriceId": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
+    "isToken2022": false
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | string | Token ticker symbol |
+| `mintKey` | string | SPL token mint address (base58) |
+| `decimals` | number | Token native decimals |
+| `usdPrecision` | number | Display precision for USD values |
+| `tokenPrecision` | number | Display precision for token amounts |
+| `isStable` | boolean | Whether token is a stablecoin |
+| `isVirtual` | boolean | Whether token is a virtual (synthetic) asset |
+| `lazerId` | number | Pyth Lazer feed ID |
+| `pythTicker` | string | Pyth ticker string (e.g. "Crypto.SOL/USD") |
+| `pythPriceId` | string | Pyth price feed ID (hex) |
+| `isToken2022` | boolean | Whether token uses SPL Token-2022 standard |
+
+---
+
+## Prices
+
+### `GET /prices`
+
+Returns all current oracle prices keyed by token symbol. Prices come from Pyth Lazer feeds (real-time, ~200ms updates). SOL and WSOL share the same feed and both keys are returned.
+
+**Response `200`:**
+
+```json
+{
+  "SOL": {
+    "price": 14852000000,
+    "exponent": -8,
+    "confidence": 0,
+    "priceUi": 148.52,
+    "timestampUs": 1707900000000000,
+    "marketSession": "regular"
+  },
+  "BTC": {
+    "price": 6500000000000,
+    "exponent": -8,
+    "confidence": 0,
+    "priceUi": 65000.0,
+    "timestampUs": 1707900000000000,
+    "marketSession": "regular"
+  },
+  "WSOL": {
+    "price": 14852000000,
+    "exponent": -8,
+    "confidence": 0,
+    "priceUi": 148.52,
+    "timestampUs": 1707900000000000,
+    "marketSession": "regular"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `price` | number | Raw integer price (multiply by `10^exponent` for decimal) |
+| `exponent` | number | Price exponent (typically -8) |
+| `confidence` | number | Confidence interval (always 0 for Lazer feeds) |
+| `priceUi` | number | Human-readable price as float |
+| `timestampUs` | number | Price timestamp in microseconds since epoch |
+| `marketSession` | string | Market session status: `"regular"`, `"preMarket"`, `"postMarket"`, `"overNight"`, or `"closed"` |
+
+### `GET /prices/{symbol}`
+
+Returns the price for a single token. Symbol lookup is case-insensitive.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `symbol` | path | string | yes | Token symbol (e.g. `SOL`, `BTC`, `ETH`) |
+
+**Response `200`:** Single `PriceResponse` object (same shape as above).
+
+**Response `404`:** `{ "error": "price for symbol 'XYZ' not found" }`
+
+---
+
+## Pool Data
+
+Aggregated pool statistics computed every 15 seconds. Includes TVL, utilization, LP price, custody ratios, and capacity metrics.
+
+### `GET /pool-data`
+
+Returns all pool data snapshots.
+
+**Response `200`:**
+
+```json
+{
+  "pools": [
+    {
+      "poolName": "Crypto Pool",
+      "poolAddress": "2RLpwpC1X2FyMnVpwMGo9dTr8jGMfxHzU2S94MbYHBqn",
+      "lpStats": {
+        "lpTokenSupply": "1250000.00",
+        "totalPoolValueUsd": "15000000.00",
+        "lpPrice": "1.2000",
+        "stableCoinPercentage": "35.20",
+        "maxAumUsd": "50000000.00"
+      },
+      "custodyStats": [
+        {
+          "symbol": "SOL",
+          "custodyAccount": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+          "priceUi": "148.52",
+          "minRatioUi": "5.00",
+          "maxRatioUi": "45.00",
+          "targetRatioUi": "25.00",
+          "currentRatioUi": "30.50",
+          "utilizationUi": "42.30",
+          "lockedAmountUi": "12500.0000",
+          "assetsOwnedAmountUi": "29550.0000",
+          "totalUsdOwnedAmountUi": "4389810.00",
+          "availableToAddAmountUi": "14600.2500",
+          "availableToAddUsdUi": "2168325.00",
+          "availableToRemoveAmountUi": "25600.5000",
+          "availableToRemoveUsdUi": "3801682.00",
+          "minCapacityAmountUi": "5050.0000",
+          "maxCapacityAmountUi": "45450.0000",
+          "rewardPerLpStaked": "123456789",
+          "openPositionFeeRate": "360",
+          "closePositionFeeRate": "360",
+          "limitPriceBufferBps": "100",
+          "maxLeverage": "100.00",
+          "maxDegenLeverage": "200.00",
+          "delaySeconds": "0"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### LP Stats Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `lpTokenSupply` | string | Total LP tokens in circulation (UI format) |
+| `totalPoolValueUsd` | string | Total pool value in USD (UI format) |
+| `lpPrice` | string | LP token price in USD (UI format) |
+| `stableCoinPercentage` | string | Percentage of pool value in stablecoins |
+| `maxAumUsd` | string | Pool's maximum AUM limit in USD (UI format) |
+
+#### Custody Stats Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | string | Token symbol |
+| `custodyAccount` | string | Custody account pubkey (base58) |
+| `priceUi` | string | Current oracle price (UI format) |
+| `minRatioUi` | string | Minimum pool ratio percentage |
+| `maxRatioUi` | string | Maximum pool ratio percentage |
+| `targetRatioUi` | string | Target pool ratio percentage |
+| `currentRatioUi` | string | Current pool ratio percentage |
+| `utilizationUi` | string | Utilization rate percentage (locked / owned * 100) |
+| `lockedAmountUi` | string | Locked token amount (UI format) |
+| `assetsOwnedAmountUi` | string | Total owned token amount (UI format) |
+| `totalUsdOwnedAmountUi` | string | Total owned value in USD (UI format) |
+| `availableToAddAmountUi` | string | Amount available to add as LP (token) |
+| `availableToAddUsdUi` | string | Amount available to add as LP (USD) |
+| `availableToRemoveAmountUi` | string | Amount available to remove as LP (token) |
+| `availableToRemoveUsdUi` | string | Amount available to remove as LP (USD) |
+| `minCapacityAmountUi` | string | Minimum capacity in token amount |
+| `maxCapacityAmountUi` | string | Maximum capacity in token amount |
+| `rewardPerLpStaked` | string | Raw u64 reward_per_lp_staked for BN math |
+| `openPositionFeeRate` | string | Raw u64 open position fee rate (divide by RATE_POWER for decimal) |
+| `closePositionFeeRate` | string | Raw u64 close position fee rate (divide by RATE_POWER for decimal) |
+| `limitPriceBufferBps` | string | Limit order price buffer in basis points |
+| `maxLeverage` | string | Maximum allowed leverage (UI format, e.g. "100.00") |
+| `maxDegenLeverage` | string | Maximum degen-mode leverage (UI format, e.g. "200.00") |
+| `delaySeconds` | string | Pricing delay in seconds |
+
+### `GET /pool-data/{pool_pubkey}`
+
+Returns data for a single pool.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `pool_pubkey` | path | string | yes | Pool public key (base58) |
+
+**Response `200`:** Single `PoolDataSnapshot` object (same shape as one element in the `pools` array above).
+
+**Response `404`:** `{ "error": "pool data for {pool_pubkey} not found" }`
+
+### `GET /pool-data/status/initialized`
+
+Returns whether pool data has been computed at least once after startup.
+
+**Response `200`:**
+
+```json
+{
+  "initialized": true
+}
+```
+
+---
+
+## Transaction Builder -- Trading
+
+All transaction builder endpoints return a base64-encoded versioned Solana transaction (unsigned). The client must sign and submit.
+
+### Open Position
+
+#### `POST /transaction-builder/open-position`
+
+Opens a new position or increases an existing one. Supports market orders, limit orders, and swaps. Optionally attaches TP/SL trigger orders.
+
+**Preview-only mode:** Omit the `owner` field to get fee/leverage/entry-price calculations without building a transaction. The response will have `transactionBase64: null`.
+
+**Request body:**
+
+```json
+{
+  "inputTokenSymbol": "USDC",
+  "outputTokenSymbol": "SOL",
+  "inputAmountUi": "100.0",
+  "leverage": 5.0,
+  "tradeType": "LONG",
+  "orderType": "MARKET",
+  "limitPrice": "150.00",
+  "degenMode": false,
+  "tradingFeeDiscountPercent": 10.0,
+  "userWhitelistAccount": "Hx4F8GnLq7bMwJgPE1osD4jGpSfR4VF2",
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+  "slippagePercentage": "0.5",
+  "takeProfit": "160.00",
+  "stopLoss": "130.00",
+  "tokenStakeFafAccount": "FAFxR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "userReferralAccount": "REF1xR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "enableFundedWallet": false,
+  "privilege": "STAKE"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inputTokenSymbol` | string | yes | Token symbol to pay with (e.g. "USDC", "SOL") |
+| `outputTokenSymbol` | string | yes | Target market token symbol (e.g. "SOL", "BTC", "ETH") |
+| `inputAmountUi` | string | yes | Input amount in human-readable format |
+| `leverage` | number | yes | Desired leverage multiplier |
+| `tradeType` | enum | yes | `"LONG"`, `"SHORT"`, or `"SWAP"` |
+| `orderType` | enum | no | `"MARKET"` (default) or `"LIMIT"` |
+| `limitPrice` | string | no | Trigger price for limit orders (UI format) |
+| `degenMode` | boolean | no | Enable degen mode (higher max leverage) |
+| `tradingFeeDiscountPercent` | number | no | Fee discount percentage from staking (0-100) |
+| `userWhitelistAccount` | string | no | Whitelist account pubkey |
+| `owner` | string | no | Wallet pubkey. **Omit for preview-only mode** (no tx built) |
+| `slippagePercentage` | string | no | Slippage tolerance percentage (default: "0.5") |
+| `takeProfit` | string | no | TP trigger price (UI format). Appends a TP trigger order instruction |
+| `stopLoss` | string | no | SL trigger price (UI format). Appends a SL trigger order instruction |
+| `tokenStakeFafAccount` | string | no | Token stake FAF account for fee discounts |
+| `userReferralAccount` | string | no | Referral account for referral privilege |
+| `enableFundedWallet` | boolean | no | Enable funded wallet privilege |
+| `privilege` | enum | no | `"NONE"`, `"STAKE"`, or `"REFERRAL"`. Overrides automatic inference |
+
+**Response `200`:**
+
+```json
+{
+  "oldLeverage": "4.50",
+  "newLeverage": "5.00",
+  "oldEntryPrice": "145.00",
+  "newEntryPrice": "148.52",
+  "oldLiquidationPrice": "118.00",
+  "newLiquidationPrice": "120.30",
+  "entryFee": "0.45",
+  "entryFeeBeforeDiscount": "0.50",
+  "openPositionFeePercent": "0.03600",
+  "availableLiquidity": "1234567.89",
+  "youPayUsdUi": "100.00",
+  "youRecieveUsdUi": "500.00",
+  "marginFeePercentage": "0.00800",
+  "outputAmount": "3370000000",
+  "outputAmountUi": "3.37",
+  "transactionBase64": "AQAAAA...",
+  "swapInPriceUi": "148.52",
+  "swapOutPriceUi": "1.00",
+  "swapFeeUsdUi": "0.45",
+  "takeProfitQuote": {
+    "exitPriceUi": "155.00",
+    "profitUsdUi": "12.50",
+    "lossUsdUi": "0",
+    "exitFeeUsdUi": "0.45",
+    "receiveUsdUi": "112.05",
+    "pnlPercentage": "12.50"
+  },
+  "stopLossQuote": {
+    "exitPriceUi": "130.00",
+    "profitUsdUi": "0",
+    "lossUsdUi": "8.25",
+    "exitFeeUsdUi": "0.40",
+    "receiveUsdUi": "91.35",
+    "pnlPercentage": "-8.25"
+  },
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `oldLeverage` | string? | Existing position leverage (only when increasing position) |
+| `newLeverage` | string | New position leverage after this trade |
+| `oldEntryPrice` | string? | Existing entry price (only when increasing position) |
+| `newEntryPrice` | string | Weighted-average entry price after this trade |
+| `oldLiquidationPrice` | string? | Existing liquidation price (only when increasing position) |
+| `newLiquidationPrice` | string | New liquidation price |
+| `entryFee` | string | Entry fee in USD after discount |
+| `entryFeeBeforeDiscount` | string | Entry fee in USD before discount |
+| `openPositionFeePercent` | string | Fee rate as percentage (e.g. "0.03600" = 0.036%) |
+| `availableLiquidity` | string | Available liquidity for this market in USD |
+| `youPayUsdUi` | string | Total collateral paid in USD |
+| `youRecieveUsdUi` | string | Position size received in USD. **Note:** "Recieve" is an intentional misspelling matching the backend field name — do not correct it. |
+| `marginFeePercentage` | string | Hourly borrow rate percentage |
+| `outputAmount` | string | Output size in native units (raw u64) |
+| `outputAmountUi` | string | Output size in human-readable format |
+| `transactionBase64` | string? | Base64-encoded versioned transaction (null when `owner` omitted) |
+| `swapInPriceUi` | string? | Swap: min oracle price of input token |
+| `swapOutPriceUi` | string? | Swap: max oracle price of output token |
+| `swapFeeUsdUi` | string? | Swap: total fee in USD |
+| `takeProfitQuote` | object? | TP trigger order quote (when `takeProfit` provided) |
+| `stopLossQuote` | object? | SL trigger order quote (when `stopLoss` provided) |
+| `err` | string? | Error message if computation failed |
+
+---
+
+### Close Position
+
+#### `POST /transaction-builder/close-position`
+
+Closes or partially closes an existing position.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "inputUsdUi": "500.00",
+  "withdrawTokenSymbol": "USDC",
+  "keepLeverageSame": false,
+  "slippagePercentage": "0.5",
+  "tradingFeeDiscountPercent": 10.0,
+  "tokenStakeFafAccount": "FAFxR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "userReferralAccount": "REF1xR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "enableFundedWallet": false,
+  "privilege": "STAKE"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey to close |
+| `inputUsdUi` | string | yes | USD amount to close. Use full size for complete close, partial for partial close |
+| `withdrawTokenSymbol` | string | yes | Token to receive (e.g. "USDC", "SOL") |
+| `keepLeverageSame` | boolean | no | Maintain current leverage during partial close |
+| `slippagePercentage` | string | no | Slippage tolerance percentage (default: "0.5") |
+| `tradingFeeDiscountPercent` | number | no | Fee discount from staking (0-100) |
+| `tokenStakeFafAccount` | string | no | Token stake FAF account for fee discounts |
+| `userReferralAccount` | string | no | Referral account for referral privilege |
+| `enableFundedWallet` | boolean | no | Enable funded wallet privilege |
+| `privilege` | enum | no | `"NONE"`, `"STAKE"`, or `"REFERRAL"` |
+
+**Response `200`:**
+
+```json
+{
+  "receiveTokenSymbol": "USDC",
+  "receiveTokenAmountUi": "105.23",
+  "receiveTokenAmountUsdUi": "105.23",
+  "markPrice": "148.52",
+  "entryPrice": "145.00",
+  "existingLiquidationPrice": "120.30",
+  "newLiquidationPrice": "0.00",
+  "existingSize": "500.00",
+  "newSize": "0.00",
+  "existingCollateral": "100.00",
+  "newCollateral": "0.00",
+  "existingLeverage": "5.00",
+  "newLeverage": "0.00",
+  "settledPnl": "5.23",
+  "fees": "0.36",
+  "feesBeforeDiscount": "0.40",
+  "lockAndUnsettledFeeUsd": "0.15",
+  "transactionBase64": "AQAAAA...",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `receiveTokenSymbol` | string | Token being received |
+| `receiveTokenAmountUi` | string | Receive amount in token (UI format) |
+| `receiveTokenAmountUsdUi` | string | Receive amount in USD |
+| `markPrice` | string | Current mark/exit price |
+| `entryPrice` | string | Position entry price |
+| `existingLiquidationPrice` | string | Liquidation price before close |
+| `newLiquidationPrice` | string | Liquidation price after close ("0" for full close) |
+| `existingSize` | string | Position size before close (USD) |
+| `newSize` | string | Remaining size after close (USD) |
+| `existingCollateral` | string | Collateral before close (USD) |
+| `newCollateral` | string | Remaining collateral after close (USD) |
+| `existingLeverage` | string | Leverage before close |
+| `newLeverage` | string | Leverage after close |
+| `settledPnl` | string | Settled PnL in USD (negative prefixed with "-") |
+| `fees` | string | Total fees (exit + borrow) in USD after discount |
+| `feesBeforeDiscount` | string | Total fees before discount |
+| `lockAndUnsettledFeeUsd` | string? | Lock and unsettled fee (partial closes) |
+| `transactionBase64` | string? | Base64-encoded versioned transaction |
+| `err` | string? | Error message if computation failed |
+
+---
+
+### Reverse Position
+
+#### `POST /transaction-builder/reverse-position`
+
+Reverses an existing position (close Long, open Short with same collateral, or vice versa). Builds a combined close+open transaction.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+  "slippagePercentage": "0.5",
+  "tradingFeeDiscountPercent": 10.0,
+  "tokenStakeFafAccount": "FAFxR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "userReferralAccount": "REF1xR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "enableFundedWallet": false,
+  "privilege": "STAKE",
+  "degenMode": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey to reverse |
+| `owner` | string | yes | Wallet pubkey (required -- builds combined transaction) |
+| `slippagePercentage` | string | no | Slippage tolerance (default: "0.5") |
+| `tradingFeeDiscountPercent` | number | no | Fee discount from staking (0-100) |
+| `tokenStakeFafAccount` | string | no | Token stake FAF account |
+| `userReferralAccount` | string | no | Referral account |
+| `enableFundedWallet` | boolean | no | Enable funded wallet privilege |
+| `privilege` | enum | no | `"NONE"`, `"STAKE"`, or `"REFERRAL"` |
+| `degenMode` | boolean | no | Enable degen mode for the new position |
+
+**Response `200`:**
+
+```json
+{
+  "closeReceiveUsd": "105.23",
+  "closeFees": "0.36",
+  "closeSettledPnl": "5.23",
+  "newSide": "Short",
+  "newLeverage": "5.00",
+  "newEntryPrice": "148.52",
+  "newLiquidationPrice": "175.00",
+  "newSizeUsd": "500.00",
+  "newSizeAmountUi": "3.37",
+  "newCollateralUsd": "98.00",
+  "openEntryFee": "0.45",
+  "transactionBase64": "AQAAAA...",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `closeReceiveUsd` | string | USD received from closing (after fees) |
+| `closeFees` | string | Total close fees in USD |
+| `closeSettledPnl` | string | Settled PnL from the close (negative = "-X.XX") |
+| `newSide` | string | New position side: "Long" or "Short" |
+| `newLeverage` | string | New position leverage |
+| `newEntryPrice` | string | New position entry price |
+| `newLiquidationPrice` | string | New position liquidation price |
+| `newSizeUsd` | string | New position size in USD |
+| `newSizeAmountUi` | string | New position size in target token |
+| `newCollateralUsd` | string | Collateral for new position (after 2% haircut) |
+| `openEntryFee` | string | Entry fee for the new position in USD |
+| `transactionBase64` | string? | Base64-encoded versioned transaction (close + open combined) |
+| `err` | string? | Error message if computation failed |
+
+---
+
+## Transaction Builder -- Collateral
+
+### Add Collateral
+
+#### `POST /transaction-builder/add-collateral`
+
+Adds collateral to an existing position, reducing leverage.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "depositAmountUi": "50.0",
+  "depositTokenSymbol": "USDC",
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+  "slippagePercentage": "0.5"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey |
+| `depositAmountUi` | string | yes | Amount to deposit (UI format, in deposit token) |
+| `depositTokenSymbol` | string | yes | Deposit token symbol (e.g. "USDC", "SOL") |
+| `owner` | string | yes | Wallet pubkey (always required) |
+| `slippagePercentage` | string | no | Slippage tolerance (default: "0.5") |
+
+**Response `200`:**
+
+```json
+{
+  "existingCollateralUsd": "100.00",
+  "newCollateralUsd": "150.00",
+  "existingLeverage": "5.00",
+  "newLeverage": "3.33",
+  "existingLiquidationPrice": "120.30",
+  "newLiquidationPrice": "105.00",
+  "depositUsdValue": "50.00",
+  "maxAddableUsd": "10000.00",
+  "transactionBase64": "AQAAAA...",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `existingCollateralUsd` | string | Current collateral in USD |
+| `newCollateralUsd` | string | Collateral after adding |
+| `existingLeverage` | string | Current leverage |
+| `newLeverage` | string | New leverage after adding |
+| `existingLiquidationPrice` | string | Current liquidation price |
+| `newLiquidationPrice` | string | New liquidation price |
+| `depositUsdValue` | string | USD value of the deposit |
+| `maxAddableUsd` | string | Maximum addable amount in USD |
+| `transactionBase64` | string? | Base64-encoded versioned transaction |
+| `err` | string? | Error message if computation failed |
+
+---
+
+### Remove Collateral
+
+#### `POST /transaction-builder/remove-collateral`
+
+Removes collateral from an existing position, increasing leverage.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "withdrawAmountUsdUi": "25.00",
+  "withdrawTokenSymbol": "USDC",
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+  "slippagePercentage": "0.5"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey |
+| `withdrawAmountUsdUi` | string | yes | USD amount to withdraw |
+| `withdrawTokenSymbol` | string | yes | Token to receive (e.g. "USDC", "SOL") |
+| `owner` | string | yes | Wallet pubkey (always required) |
+| `slippagePercentage` | string | no | Slippage tolerance (default: "0.5") |
+
+**Response `200`:**
+
+```json
+{
+  "existingCollateralUsd": "100.00",
+  "newCollateralUsd": "75.00",
+  "existingLeverage": "5.00",
+  "newLeverage": "6.67",
+  "existingLiquidationPrice": "120.30",
+  "newLiquidationPrice": "130.00",
+  "receiveAmountUi": "25.00",
+  "receiveAmountUsdUi": "25.00",
+  "maxWithdrawableUsd": "80.00",
+  "transactionBase64": "AQAAAA...",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `existingCollateralUsd` | string | Current collateral in USD |
+| `newCollateralUsd` | string | Collateral after removing |
+| `existingLeverage` | string | Current leverage |
+| `newLeverage` | string | New leverage after removing |
+| `existingLiquidationPrice` | string | Current liquidation price |
+| `newLiquidationPrice` | string | New liquidation price |
+| `receiveAmountUi` | string | Amount to receive in withdraw token |
+| `receiveAmountUsdUi` | string | USD value of receive amount |
+| `maxWithdrawableUsd` | string | Maximum withdrawable in USD |
+| `transactionBase64` | string? | Base64-encoded versioned transaction |
+| `err` | string? | Error message if computation failed |
+
+---
+
+## Transaction Builder -- Trigger Orders
+
+Trigger orders are take-profit (TP) and stop-loss (SL) orders that automatically close part or all of a position when a price threshold is reached.
+
+These endpoints return structured errors with HTTP status codes (400, 404, 500) using the `{ "err": "..." }` format.
+
+### Place Trigger Order
+
+#### `POST /transaction-builder/place-trigger-order`
+
+Places a new TP or SL trigger order on an existing position.
+
+**Request body:**
+
+```json
+{
+  "marketSymbol": "SOL",
+  "side": "LONG",
+  "triggerPriceUi": "160.00",
+  "sizeAmountUi": "0.5",
+  "isStopLoss": false,
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `marketSymbol` | string | yes | Market symbol (e.g. "SOL", "BTC") |
+| `side` | enum | yes | Trade side: `"LONG"` or `"SHORT"` |
+| `triggerPriceUi` | string | yes | Trigger price in UI format |
+| `sizeAmountUi` | string | yes | Size to close in target token when trigger fires |
+| `isStopLoss` | boolean | yes | `true` for stop-loss, `false` for take-profit |
+| `owner` | string | yes | Wallet pubkey (position owner) |
+
+**Response `200`:**
+
+```json
+{
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+**Error responses:** `400`, `404`, `500` with `{ "err": "message" }`
+
+---
+
+### Edit Trigger Order
+
+#### `POST /transaction-builder/edit-trigger-order`
+
+Edits an existing trigger order's price and size.
+
+**Request body:**
+
+```json
+{
+  "marketSymbol": "SOL",
+  "side": "LONG",
+  "orderId": 0,
+  "triggerPriceUi": "165.00",
+  "sizeAmountUi": "0.5",
+  "isStopLoss": false,
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `marketSymbol` | string | yes | Market symbol |
+| `side` | enum | yes | `"LONG"` or `"SHORT"` |
+| `orderId` | number | yes | Index of the trigger order to edit (0-4) |
+| `triggerPriceUi` | string | yes | New trigger price in UI format |
+| `sizeAmountUi` | string | yes | New size in target token |
+| `isStopLoss` | boolean | yes | `true` for SL, `false` for TP |
+| `owner` | string | yes | Wallet pubkey (must be original order owner) |
+
+**Response `200`:**
+
+```json
+{
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+**Error responses:** `400`, `404`, `500` with `{ "err": "message" }`
+
+---
+
+### Cancel Trigger Order
+
+#### `POST /transaction-builder/cancel-trigger-order`
+
+Cancels a single trigger order.
+
+**Request body:**
+
+```json
+{
+  "marketSymbol": "SOL",
+  "side": "LONG",
+  "orderId": 0,
+  "isStopLoss": false,
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `marketSymbol` | string | yes | Market symbol |
+| `side` | enum | yes | `"LONG"` or `"SHORT"` |
+| `orderId` | number | yes | Index of the trigger order to cancel (0-4) |
+| `isStopLoss` | boolean | yes | `true` for SL, `false` for TP |
+| `owner` | string | yes | Wallet pubkey (must own the order) |
+
+**Response `200`:**
+
+```json
+{
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+**Error responses:** `400`, `404`, `500` with `{ "err": "message" }`
+
+---
+
+### Cancel All Trigger Orders
+
+#### `POST /transaction-builder/cancel-all-trigger-orders`
+
+Cancels all trigger orders for a given market and side.
+
+**Request body:**
+
+```json
+{
+  "marketSymbol": "SOL",
+  "side": "LONG",
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `marketSymbol` | string | yes | Market symbol |
+| `side` | enum | yes | `"LONG"` or `"SHORT"` |
+| `owner` | string | yes | Wallet pubkey (must own the orders) |
+
+**Response `200`:**
+
+```json
+{
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+**Error responses:** `400`, `404`, `500` with `{ "err": "message" }`
+
+---
+
+## Transaction Builder -- Account Setup
+
+### Init Token Stake
+
+#### `POST /transaction-builder/init-token-stake`
+
+Initializes a token stake (FAF) account PDA for the user. Required before staking for fee discounts.
+
+**Request body:**
+
+```json
+{
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `owner` | string | yes | Wallet pubkey |
+
+**Response `200`:**
+
+```json
+{
+  "tokenStakeAccount": "FAFxR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tokenStakeAccount` | string | Derived token stake account PDA |
+| `transactionBase64` | string | Base64-encoded versioned transaction |
+
+---
+
+### Create Referral
+
+#### `POST /transaction-builder/create-referral`
+
+Creates a referral account linking the user to a referrer.
+
+**Request body:**
+
+```json
+{
+  "owner": "9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL",
+  "referrer": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `owner` | string | yes | Wallet pubkey of the user creating the referral account |
+| `referrer` | string | yes | Referrer's wallet pubkey (their token stake PDA is derived automatically) |
+
+**Response `200`:**
+
+```json
+{
+  "referralAccount": "REF1xR2D3YBQu4A7t5WCbTfLJ88gkQTZ2c8oKGPujNbqo",
+  "transactionBase64": "AQAAAA..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `referralAccount` | string | Derived referral account PDA |
+| `transactionBase64` | string | Base64-encoded versioned transaction |
+
+---
+
+## Previews
+
+Preview endpoints perform fee, PnL, and margin calculations without building any transaction. Used for UI display before the user commits to a trade.
+
+### Limit Order Fees
+
+#### `POST /preview/limit-order-fees`
+
+Calculates entry price, fee, liquidation price, and borrow rate for a limit order.
+
+**Request body:**
+
+```json
+{
+  "marketSymbol": "SOL",
+  "inputAmountUi": "100.0",
+  "outputAmountUi": "0.67",
+  "side": "LONG",
+  "limitPrice": "150.00",
+  "tradingFeeDiscountPercent": 10.0
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `marketSymbol` | string | yes | Market symbol (e.g. "SOL", "BTC") |
+| `inputAmountUi` | string | yes | Input (collateral) amount in UI format |
+| `outputAmountUi` | string | yes | Output (size) amount in UI format |
+| `side` | enum | yes | `"LONG"` or `"SHORT"` |
+| `limitPrice` | string | no | Limit price in UI format (uses live price if omitted) |
+| `tradingFeeDiscountPercent` | number | no | Fee discount from staking (0-100) |
+
+**Response `200`:**
+
+```json
+{
+  "entryPriceUi": "148.52",
+  "entryFeeUsdUi": "0.50",
+  "liquidationPriceUi": "120.30",
+  "borrowRateUi": "0.01200",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entryPriceUi` | string | Computed entry price |
+| `entryFeeUsdUi` | string | Entry fee in USD |
+| `liquidationPriceUi` | string | Liquidation price |
+| `borrowRateUi` | string | Hourly borrow rate (decimal format) |
+| `err` | string? | Error message if computation failed |
+
+---
+
+### Exit Fee
+
+#### `POST /preview/exit-fee`
+
+Calculates exit fee and exit price for closing a position.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "closeAmountUsdUi": "500.00"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey |
+| `closeAmountUsdUi` | string | yes | USD amount to close |
+
+**Response `200`:**
+
+```json
+{
+  "exitFeeUsdUi": "0.40",
+  "exitFeeAmountUi": "0.002700",
+  "exitPriceUi": "148.52",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exitFeeUsdUi` | string | Exit fee in USD |
+| `exitFeeAmountUi` | string | Exit fee in token amount |
+| `exitPriceUi` | string | Exit price after spread |
+| `err` | string? | Error message |
+
+---
+
+### TP/SL Preview
+
+#### `POST /preview/tp-sl`
+
+Calculates TP/SL projections. Three modes:
+
+- **`forward`** -- Given a trigger price, compute projected PnL
+- **`reverse_pnl`** -- Given a target PnL in USD, compute the required trigger price
+- **`reverse_roi`** -- Given a target ROI percentage, compute the required trigger price
+
+Works with both existing positions (via `positionKey`) and hypothetical limit orders (via inline fields).
+
+**Request body (forward mode, existing position):**
+
+```json
+{
+  "mode": "forward",
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "triggerPriceUi": "160.00"
+}
+```
+
+**Request body (reverse_pnl mode, inline limit order):**
+
+```json
+{
+  "mode": "reverse_pnl",
+  "marketSymbol": "SOL",
+  "entryPriceUi": "148.52",
+  "sizeUsdUi": "500.00",
+  "collateralUsdUi": "100.00",
+  "side": "LONG",
+  "targetPnlUsdUi": "50.00"
+}
+```
+
+**Request body (reverse_roi mode):**
+
+```json
+{
+  "mode": "reverse_roi",
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "targetRoiPercent": 50.0
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mode` | string | yes | `"forward"`, `"reverse_pnl"`, or `"reverse_roi"` |
+| `positionKey` | string | conditional | Position pubkey (for existing positions) |
+| `marketSymbol` | string | conditional | Market symbol (for inline limit orders) |
+| `entryPriceUi` | string | conditional | Entry price (for inline limit orders) |
+| `sizeUsdUi` | string | conditional | Size in USD (for inline limit orders) |
+| `collateralUsdUi` | string | conditional | Collateral in USD (for inline limit orders) |
+| `side` | enum | conditional | `"LONG"` or `"SHORT"` (for inline limit orders) |
+| `triggerPriceUi` | string | conditional | Trigger price (forward mode) |
+| `targetPnlUsdUi` | string | conditional | Target PnL in USD (reverse_pnl mode) |
+| `targetRoiPercent` | number | conditional | Target ROI percentage (reverse_roi mode) |
+
+**Response `200`:**
+
+```json
+{
+  "pnlUsdUi": "50.00",
+  "pnlPercentage": "50.00",
+  "triggerPriceUi": "160.00",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pnlUsdUi` | string? | Estimated PnL in USD (forward mode) |
+| `pnlPercentage` | string? | PnL percentage (forward mode) |
+| `triggerPriceUi` | string? | Computed trigger price (reverse modes) |
+| `err` | string? | Error message |
+
+---
+
+### Margin Preview
+
+#### `POST /preview/margin`
+
+Previews the effect of adding or removing collateral on leverage and liquidation price.
+
+**Request body:**
+
+```json
+{
+  "positionKey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "marginDeltaUsdUi": "50.00",
+  "action": "ADD"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `positionKey` | string | yes | Position account pubkey |
+| `marginDeltaUsdUi` | string | yes | Margin delta in USD |
+| `action` | enum | yes | `"ADD"` or `"REMOVE"` |
+
+**Response `200`:**
+
+```json
+{
+  "newLeverageUi": "3.50",
+  "newLiquidationPriceUi": "110.00",
+  "maxAmountUsdUi": "500.00",
+  "err": null
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `newLeverageUi` | string | New leverage after margin change |
+| `newLiquidationPriceUi` | string | New liquidation price |
+| `maxAmountUsdUi` | string | Maximum addable/removable amount in USD |
+| `err` | string? | Error message |
+
+---
+
+## WebSocket Streaming
+
+### `GET /owner/{owner}/ws`
+
+Upgrades to a WebSocket connection that streams real-time enriched positions and orders for a specific owner.
+
+| Parameter | In | Type | Required | Description |
+|-----------|------|--------|----------|-------------|
+| `owner` | path | string | yes | Owner wallet public key (base58) |
+| `includePnlInLeverageDisplay` | query | boolean | yes | Include PnL in leverage display calculation |
+| `updateIntervalMs` | query | number | no | Position update interval in milliseconds (default: 1000, min: 100, max: 10000) |
+
+**Connection example:**
+
+```
+ws://$FLASH_API_URL/owner/9erjj6n8Hkrv9dVK1CjJatSNfCgUP6EbQ2hRbrsokRuL/ws?includePnlInLeverageDisplay=true&updateIntervalMs=1000
+```
+
+**Message format:**
+
+The server sends two types of JSON messages:
+
+**Positions update (sent at `updateIntervalMs` interval):**
+
+```json
+{
+  "type": "positions",
+  "data": [
+    { /* PositionTableDataUiDto -- same shape as GET /positions/owner/{owner} */ }
+  ]
+}
+```
+
+**Orders update (sent only when orders change on-chain):**
+
+```json
+{
+  "type": "orders",
+  "data": [
+    { /* OrderDataUiDto -- same shape as GET /orders/owner/{owner} */ }
+  ]
+}
+```
+
+### Connection Behavior
+
+- On connect, the server immediately sends both a `positions` and an `orders` message with the current state.
+- Positions are recalculated at the configured interval (price-dependent).
+- Orders are only re-sent when on-chain order accounts change (event-driven via gRPC).
+- Server sends WebSocket Ping frames every 30 seconds. If no Pong is received within 10 seconds, the connection is closed.
+- The client does not need to send any messages after connecting.
+
+### Connection Limits
+
+| Limit | Value |
+|-------|-------|
+| Global connections | 10,000 |
+| Per-owner connections | 5 |
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| `429` | Per-owner connection limit reached (5 connections) |
+| `503` | Global connection limit reached (10,000 connections) |
+
+---
+
+## Enum Reference
+
+### TradeType
+
+Serialized as `SCREAMING_SNAKE_CASE`:
+
+| Value | Description |
+|-------|-------------|
+| `LONG` | Long position |
+| `SHORT` | Short position |
+| `SWAP` | Token swap (no leverage) |
+
+### OrderType
+
+Serialized as `SCREAMING_SNAKE_CASE`:
+
+| Value | Description |
+|-------|-------------|
+| `MARKET` | Market order (executes immediately) |
+| `LIMIT` | Limit order (executes at trigger price) |
+
+### PrivilegeType
+
+Serialized as `SCREAMING_SNAKE_CASE`:
+
+| Value | Description |
+|-------|-------------|
+| `NONE` | No privilege |
+| `REFERRAL` | Referred user privilege |
+| `STAKE` | FAF staker privilege |
+
+### MarginAction
+
+Serialized as `SCREAMING_SNAKE_CASE`:
+
+| Value | Description |
+|-------|-------------|
+| `ADD` | Add collateral to position |
+| `REMOVE` | Remove collateral from position |
+
+---
+
+## Quick Reference: All Endpoints
+
+| Method | Path | Tag |
+|--------|------|-----|
+| `GET` | `/health` | Health |
+| `GET` | `/raw/perpetuals` | Raw Accounts |
+| `GET` | `/raw/perpetuals/{pubkey}` | Raw Accounts |
+| `GET` | `/raw/pools` | Raw Accounts |
+| `GET` | `/raw/pools/{pubkey}` | Raw Accounts |
+| `GET` | `/raw/custodies` | Raw Accounts |
+| `GET` | `/raw/custodies/{pubkey}` | Raw Accounts |
+| `GET` | `/raw/markets` | Raw Accounts |
+| `GET` | `/raw/markets/{pubkey}` | Raw Accounts |
+| `GET` | `/raw/positions/{pubkey}` | Raw Accounts |
+| `GET` | `/raw/orders/{pubkey}` | Raw Accounts |
+| `GET` | `/positions/owner/{owner}` | Positions |
+| `GET` | `/orders/owner/{owner}` | Orders |
+| `GET` | `/tokens` | Tokens |
+| `GET` | `/prices` | Prices |
+| `GET` | `/prices/{symbol}` | Prices |
+| `GET` | `/pool-data` | Pool Data |
+| `GET` | `/pool-data/{pool_pubkey}` | Pool Data |
+| `GET` | `/pool-data/status/initialized` | Pool Data |
+| `POST` | `/transaction-builder/open-position` | Trading |
+| `POST` | `/transaction-builder/close-position` | Trading |
+| `POST` | `/transaction-builder/reverse-position` | Trading |
+| `POST` | `/transaction-builder/add-collateral` | Collateral |
+| `POST` | `/transaction-builder/remove-collateral` | Collateral |
+| `POST` | `/transaction-builder/place-trigger-order` | Trigger Orders |
+| `POST` | `/transaction-builder/edit-trigger-order` | Trigger Orders |
+| `POST` | `/transaction-builder/cancel-trigger-order` | Trigger Orders |
+| `POST` | `/transaction-builder/cancel-all-trigger-orders` | Trigger Orders |
+| `POST` | `/transaction-builder/init-token-stake` | Account Setup |
+| `POST` | `/transaction-builder/create-referral` | Account Setup |
+| `POST` | `/preview/limit-order-fees` | Previews |
+| `POST` | `/preview/exit-fee` | Previews |
+| `POST` | `/preview/tp-sl` | Previews |
+| `POST` | `/preview/margin` | Previews |
+| `GET` | `/owner/{owner}/ws` | Streaming |
+| `GET` | `/metrics` | Prometheus (not in OpenAPI) |

--- a/flash-trade/ErrorReference.md
+++ b/flash-trade/ErrorReference.md
@@ -1,0 +1,233 @@
+# Flash Trade Error Reference
+
+69 error codes from the Flash Trade perpetuals program (6000-6068), plus REST API HTTP errors.
+
+## HTTP Errors (REST API Layer)
+
+| Code | Meaning | Common Cause |
+|------|---------|--------------|
+| 400 | Bad Request | Invalid pubkey format, missing required field, invalid enum value |
+| 404 | Not Found | Account/position/order doesn't exist; price symbol unavailable |
+| 429 | Too Many Requests | Per-owner WebSocket connection limit (5) exceeded |
+| 500 | Internal Server Error | Computation failure, unexpected blockchain state |
+| 503 | Service Unavailable | Price data missing (market closed); global WebSocket limit reached |
+
+**Error response formats:**
+```json
+// General HTTP errors (400, 404, 500, etc.)
+{ "error": "descriptive error message" }
+
+// Transaction builder and trigger order domain errors
+{ "err": "descriptive error message" }
+```
+
+**Note:** The API uses two different error keys — `"error"` for HTTP-level errors and `"err"` for domain-specific computation errors (returned in transaction builder and trigger order responses). Always check for both.
+
+## On-Chain Error Codes (6000-6068)
+
+### Trading Errors (Most Common)
+
+These are the errors you'll encounter most frequently when building integrations.
+
+| Code | Name | Solution |
+|------|------|----------|
+| **6020** | **MaxPriceSlippage** | Price moved beyond `priceWithSlippage`. Widen slippage tolerance (1-3% from oracle) or retry with fresh price. |
+| **6021** | **MaxLeverage** | Post-modification leverage exceeds `max_leverage`. Reduce size or add collateral first. |
+| **6022** | **MaxInitLeverage** | New position leverage exceeds `max_init_leverage`. Reduce size or increase collateral. |
+| **6023** | **MinLeverage** | Leverage below `min_init_leverage`. Increase size or reduce collateral. |
+| **6024** | **CustodyAmountLimit** | Pool capacity reached (`max_total_locked_usd`). Try smaller position or wait. |
+| **6025** | **PositionAmountLimit** | Single position exceeds `max_position_size_usd`. Split into smaller positions. |
+| **6031** | **InstructionNotAllowed** | Trading paused by protocol (maintenance, circuit breaker). Wait and retry. |
+| **6032** | **MaxUtilization** | Pool utilization at capacity. Try smaller position or wait. |
+| **6033** | **CloseOnlyMode** | Market in close-only mode. Only close/decrease operations allowed. |
+| **6034** | **MinCollateral** | Below `min_collateral_usd`. Increase collateral (use $11-12+ for TP/SL). |
+
+### Order Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| **6049** | **InvalidStopLossPrice** | SL price doesn't make sense for position direction (e.g., SL above entry for a long). |
+| **6050** | **InvalidTakeProfitPrice** | TP price doesn't make sense (e.g., TP below entry for a long). |
+| **6051** | **ExposureLimitExceeded** | Degen Mode exposure cap hit. Reduce size or wait. |
+| **6052** | **MaxStopLossOrders** | Max 5 SL orders per market. Cancel an existing one first. |
+| **6053** | **MaxTakeProfitOrders** | Max 5 TP orders per market. Cancel an existing one first. |
+| **6054** | **MaxOpenOrder** | Max 5 limit orders per market. Cancel an existing one first. |
+| 6055 | InvalidOrder | Order doesn't exist at the specified `orderId` index (0-4). |
+| 6056 | InvalidLimitPrice | Limit price invalid for the position direction. |
+
+### Oracle Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| **6007** | **StaleOraclePrice** | Oracle price too old. Retry after a few slots. Check [Pyth status](https://status.pyth.network/). |
+| 6004 | UnsupportedOracle | Internal: custody oracle misconfigured. |
+| 6005 | InvalidOracleAccount | Wrong oracle account passed. Ensure PoolConfig is current. |
+| 6006 | InvalidOracleState | Oracle feed offline or corrupted. Wait and retry. |
+| 6008 | InvalidOraclePrice | Oracle returned 0 or negative confidence. Wait and retry. |
+
+### State Validation Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6009 | InvalidEnvironment | Test-only instruction called on mainnet. |
+| 6010 | InvalidPoolState | Pool account corrupted or uninitialized. Verify pool address. |
+| 6011 | InvalidCustodyState | Custody account issue. Re-fetch PoolConfig. |
+| 6012 | InvalidMarketState | Market account issue. Verify market exists for this pool/side. |
+| 6013 | InvalidCollateralCustody | Wrong collateral token for this market. |
+| 6014 | InvalidPositionState | Position doesn't exist or is already closed. Verify position PDA. |
+| 6015 | InvalidDispensingCustody | Internal custody routing error. |
+| 6016 | InvalidPerpetualsConfig | Global config issue. |
+| 6017 | InvalidPoolConfig | Pool parameters invalid. |
+| 6018 | InvalidCustodyConfig | Custody parameters invalid. |
+
+### Arithmetic
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6003 | MathOverflow | Reduce position size. Rare — caused by extreme sizes or prices. |
+
+### Multisig (Admin Only)
+
+| Code | Name | Notes |
+|------|------|-------|
+| 6000 | MultisigAccountNotAuthorized | Admin-only, not relevant to integrators |
+| 6001 | MultisigAlreadySigned | Admin-only |
+| 6002 | MultisigAlreadyExecuted | Admin-only |
+
+### Swap & Token Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6019 | InsufficientAmountReturned | Swap output below minimum. Increase slippage on swap portion. |
+| 6026 | TokenRatioOutOfRange | LP operation pushes allocation outside min/max ratios. Deposit underweight token. |
+| 6027 | UnsupportedToken | Token mint not recognized by pool. |
+| 6028 | UnsupportedCustody | Custody not found in pool. |
+| 6029 | UnsupportedPool | Pool address invalid. |
+| 6030 | UnsupportedMarket | Market doesn't exist for this target/collateral/side. |
+
+### Oracle Authority (Internal)
+
+| Code | Name | Notes |
+|------|------|-------|
+| 6035 | PermissionlessOracleMissingSignature | Keeper/oracle authority error |
+| 6036 | PermissionlessOracleMalformedEd25519Data | Internal oracle error |
+| 6037 | PermissionlessOracleSignerMismatch | Internal oracle error |
+| 6038 | PermissionlessOracleMessageMismatch | Internal oracle error |
+
+### Protocol Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6039 | ExponentMismatch | Internal price calculation error. |
+| 6040 | CloseRatio | Position close amount invalid relative to current size. |
+| 6041 | InsufficientStakeAmount | Trying to unstake more than staked balance. |
+| 6042 | InvalidFeeDeltas | Internal fee calculation error. |
+| 6043 | InvalidFeeDistributionCustody | Internal custody routing. |
+| 6044 | InvalidCollection | NFT collection not recognized for gated trading. |
+| 6045 | InvalidOwner | Wrong token account owner. Ensure ATA is derived correctly. |
+| 6046 | InvalidAccess | Pool requires NFT or referral for access. Create referral first. |
+| 6047 | TokenStakeAccountMismatch | Referral account linked to wrong stake account. |
+| 6048 | MaxDepositsReached | Token vault deposit limit hit. |
+
+### Reserve & Withdrawal
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6057 | MinReserve | Custody min_reserve_usd threshold. Pool must maintain reserves. |
+| 6058 | MaxWithdrawTokenRequest | Max 5 pending withdraw requests per TokenStake account. |
+
+### Reward & LP Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6059 | InvalidRewardDistribution | Admin reward distribution error. |
+| 6060 | LpPriceOutOfBounds | FLP price outside safety bounds. Pool safety mechanism. |
+| 6061 | InsufficientRebateReserves | Rebate vault insufficient balance. |
+| 6062 | OraclePenaltyAlreadySet | Position already has price impact penalty applied. |
+
+### Pyth Lazer Errors
+
+| Code | Name | Notes |
+|------|------|-------|
+| 6063 | InvalidLazerMessage | Pyth Lazer oracle message format error |
+| 6064 | InvalidLazerPayload | Pyth Lazer payload parsing failure |
+| 6065 | InvalidLazerChannel | Wrong Lazer channel for this custody |
+| 6066 | InvalidLazerTimestamp | Lazer message too old or in the future |
+
+### Withdrawal Errors
+
+| Code | Name | Solution |
+|------|------|----------|
+| 6067 | InvalidWithdrawal | Withdrawal amount invalid (0 or exceeds balance). |
+| 6068 | InvalidWithdrawRequestId | Withdraw request index doesn't exist (0-4). |
+
+## Common Scenarios & Recovery
+
+### "Transaction too large"
+Flash Trade transactions with ALTs are near the size limit. Ensure address lookup tables are loaded and use VersionedTransaction (v0), not legacy.
+
+### "Blockhash not found" / "Blockhash expired"
+Solana blockhashes expire in ~60 seconds. Re-call the transaction builder endpoint to get a fresh transaction, then sign and submit immediately.
+
+### Position not found after closing
+The API caches data ~15 seconds. After closing a position, `get_positions` may briefly still show it. The transaction is confirmed on-chain — this is normal cache lag.
+
+### Trigger orders not executing
+Trigger orders are executed by off-chain keepers:
+1. Verify oracle price has actually crossed the trigger level
+2. Check that the position still exists (not liquidated)
+3. Keepers may have latency during high-volatility periods
+
+### "Account not found" on position operations
+Position PDA doesn't exist — either never opened or already closed/liquidated. Verify position exists via `GET /positions/owner/{owner}` before operating on it.
+
+## Error Handling Pattern (TypeScript)
+
+```typescript
+try {
+  const response = await fetch(`${FLASH_API_URL}/transaction-builder/open-position`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    // Handle HTTP-level errors
+    if (response.status === 404) console.error('Market or account not found');
+    if (response.status === 503) console.error('Price data unavailable');
+    throw new Error(error);
+  }
+
+  const data = await response.json();
+  if (data.err) {
+    // Handle on-chain computation errors returned in the response body
+    console.error('Transaction builder error:', data.err);
+  }
+} catch (err) {
+  // Handle network/connection errors
+  console.error('Request failed:', err.message);
+}
+```
+
+## Error Handling Pattern (Python)
+
+```python
+import requests
+
+try:
+    response = requests.post(f"{FLASH_API_URL}/transaction-builder/open-position", json=request)
+    response.raise_for_status()
+    data = response.json()
+
+    if data.get("err"):
+        print(f"Transaction builder error: {data['err']}")
+    elif data.get("transactionBase64"):
+        print("Transaction ready to sign")
+
+except requests.exceptions.HTTPError as e:
+    error_body = e.response.json()
+    print(f"API error ({e.response.status_code}): {error_body.get('error', 'Unknown')}")
+except requests.exceptions.ConnectionError:
+    print("Cannot reach Flash Trade API")
+```

--- a/flash-trade/McpIntegration.md
+++ b/flash-trade/McpIntegration.md
@@ -1,0 +1,163 @@
+# MCP Integration
+
+## What is the MCP Server
+
+`flash-trade-mcp` is a Model Context Protocol server that wraps the Flash Trade REST API as typed MCP tools for AI agents. It is published on NPM as [`flash-trade-mcp`](https://www.npmjs.com/package/flash-trade-mcp) (v0.4.1).
+
+The server is a thin wrapper that adds:
+- **Zod input validation** on every tool call
+- **Formatted, AI-readable output** (structured JSON with computed fields)
+- **Error normalization** (HTTP errors mapped to MCP error codes)
+- **Transaction signing** via local Solana keypair (`sign_and_send` tool)
+
+It does NOT contain trading logic itself -- all execution flows through the Flash Trade REST API.
+
+---
+
+## Setup
+
+### Install and Run
+
+```bash
+# One-liner (no install required)
+npx flash-trade-mcp
+# or
+bunx flash-trade-mcp
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `FLASH_API_URL` | Yes | -- | Flash Trade API base URL (e.g. `https://flashapi.trade`) |
+| `FLASH_API_TIMEOUT` | No | `30000` | HTTP timeout in milliseconds |
+| `WALLET_PUBKEY` | No | -- | Default wallet pubkey for transaction building |
+| `KEYPAIR_PATH` | No | `~/.config/solana/id.json` | Local keypair file for `sign_and_send` |
+| `SOLANA_RPC_URL` | No | `https://api.mainnet-beta.solana.com` | Solana RPC endpoint for `sign_and_send` |
+
+### Claude Code Configuration
+
+Add to your MCP settings (`.mcp.json` or Claude Code settings):
+
+```json
+{
+  "mcpServers": {
+    "flash-trade": {
+      "command": "npx",
+      "args": ["flash-trade-mcp"],
+      "env": {
+        "FLASH_API_URL": "https://flashapi.trade",
+        "WALLET_PUBKEY": "<your-solana-pubkey>"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Tool Catalog (30 tools)
+
+### Read Tools (no transactions, no side effects)
+
+| Tool | Purpose |
+|------|---------|
+| `health_check` | Verify API connectivity |
+| `get_markets` / `get_market` | List all perp markets or get one by pubkey |
+| `get_pools` / `get_pool` | List liquidity pools or get one by pubkey |
+| `get_custodies` / `get_custody` | List custody accounts or get one by pubkey |
+| `get_prices` / `get_price` | All oracle prices or one by symbol |
+| `get_positions` / `get_position` | List positions (optionally by owner) or get one by pubkey |
+| `get_orders` / `get_order` | List orders (optionally by owner) or get one by pubkey |
+| `get_pool_data` | Pool AUM, LP stats, utilization |
+| `get_account_summary` | Complete wallet overview: positions + orders + prices |
+| `get_trading_overview` | Trading-ready snapshot: markets + prices + pool utilization |
+
+### Preview Tools (calculations only, no transactions)
+
+| Tool | Purpose |
+|------|---------|
+| `preview_limit_order_fees` | Estimate fees before placing a limit order |
+| `preview_exit_fee` | Estimate close cost for a position |
+| `preview_tp_sl` | Calculate TP/SL prices and projected PnL (forward, reverse_pnl, reverse_roi modes) |
+| `preview_margin` | Preview effect of adding/removing collateral |
+
+### Transaction Tools (return unsigned base64 transactions)
+
+| Tool | Purpose |
+|------|---------|
+| `open_position` | Open a new perpetual position |
+| `close_position` | Close or partially close a position |
+| `reverse_position` | Close current + open opposite direction |
+| `add_collateral` | Add collateral to reduce leverage |
+| `remove_collateral` | Remove collateral to increase leverage |
+
+### Trigger Order Tools (TP/SL management, return unsigned base64 transactions)
+
+| Tool | Purpose |
+|------|---------|
+| `place_trigger_order` | Place TP or SL on an existing position |
+| `edit_trigger_order` | Edit price/size on an existing TP/SL |
+| `cancel_trigger_order` | Cancel a single TP or SL order |
+| `cancel_all_trigger_orders` | Cancel all TP/SL for a market + side |
+
+### Signing Tool
+
+| Tool | Purpose |
+|------|---------|
+| `sign_and_send` | Sign a base64 transaction with local keypair and submit to Solana |
+
+For full parameter details on each tool, see the MCP server's own documentation at `flash-trade-MCP/mcp/CLAUDE.md`.
+
+---
+
+## Typical AI Agent Workflow
+
+```
+1. health_check                          --> Verify API is reachable
+2. get_trading_overview                  --> Markets, prices, pool utilization
+3. get_account_summary(owner=<wallet>)   --> Check existing positions and orders
+4. open_position(input_amount="12.0")    --> Build trade ($12+ for TP/SL support)
+   --> Show preview (fees, leverage, liquidation) to user
+   --> User approves
+5. sign_and_send(transaction_base64)     --> Sign and submit IMMEDIATELY
+6. get_account_summary(owner=<wallet>)   --> Verify position opened
+7. preview_tp_sl                         --> Calculate TP/SL levels
+8. place_trigger_order                   --> Add TP/SL
+   --> sign_and_send(transaction_base64)
+9. close_position                        --> When ready to exit
+   --> sign_and_send(transaction_base64)
+```
+
+**Critical timing**: Solana blockhashes expire in ~60 seconds. Call `sign_and_send` immediately after user approval. If you get "Blockhash not found", re-call the transaction tool and sign again.
+
+---
+
+## When to Use MCP vs REST API
+
+| Use Case | MCP Server | REST API |
+|----------|-----------|----------|
+| AI agent integration | Yes | -- |
+| Pre-validated inputs (Zod schemas) | Yes | -- |
+| Formatted, AI-readable outputs | Yes | -- |
+| Transaction signing built-in | Yes | -- |
+| Custom applications | -- | Yes |
+| Non-AI programmatic access | -- | Yes |
+| Maximum flexibility / raw responses | -- | Yes |
+| Browser-based apps | -- | Yes |
+
+The MCP server calls the same REST API underneath. Choose MCP when building AI agent workflows; choose the REST API for custom apps or when you need raw control over requests.
+
+---
+
+## MCP Resources
+
+The server exposes three MCP resources for bulk data reads:
+
+| URI | Type | Description |
+|-----|------|-------------|
+| `flash://accounts` | Static | Snapshot of all pools, custodies, markets, and global config |
+| `flash://positions/{owner}` | Template | Enriched positions for a wallet (PnL, leverage, liquidation) |
+| `flash://orders/{owner}` | Template | Limit orders, TP, and SL orders for a wallet |
+
+Resources return JSON and can be polled periodically for updates. Data is cached ~15 seconds on the API side.

--- a/flash-trade/ProtocolConcepts.md
+++ b/flash-trade/ProtocolConcepts.md
@@ -1,0 +1,176 @@
+# Flash Trade Protocol Concepts
+
+Core domain knowledge for developers integrating with Flash Trade.
+
+## Pool-to-Peer Model
+
+All trades execute against shared liquidity pools — no orderbook, no counterparty matching. Traders open leveraged positions against pool liquidity, and LPs earn fees from trading activity.
+
+```
+Pool (e.g., Crypto.1)
+├── Custody: USDC    (collateral, stable)
+├── Custody: SOL     (target, volatile)
+├── Custody: BTC     (target, volatile)
+├── Custody: ETH     (target, volatile)
+├── Market: SOL-Long   (target=SOL, collateral=USDC)
+├── Market: SOL-Short  (target=SOL, collateral=USDC)
+├── Market: BTC-Long   ...
+└── ...
+```
+
+**Benefits:** Near-zero slippage for typical trade sizes, instant settlement (single transaction), deep liquidity from aggregated LP deposits.
+
+## Key Entities
+
+### Pool
+A liquidity container holding multiple token custodies and defining tradable markets. Each pool has its own FLP token for liquidity providers.
+
+**Available pools:**
+
+| Category | Example | Assets |
+|----------|---------|--------|
+| Crypto | `Crypto.1` | USDC, SOL, BTC, ETH, JitoSOL |
+| Virtual | `Virtual.1` | USDC, XAU, XAG, EUR, GBP, CRUDEOIL |
+| Governance | `Governance.1` | USDC, JUP, PYTH, JTO, RAY |
+| Community | `Community.1`, `Community.2` | USDC, BONK, PENGU, WIF |
+| RWA | `Remora.1` | USDC, TSLAr, NVDAr, SPYr |
+
+### Custody
+A token's configuration within a pool — fees, oracle setup, pricing limits, borrow rates. Each custody has independent parameters.
+
+### Market
+A tradable pair within a pool. Defined by: target custody + collateral custody + side (Long/Short). Markets have individual permissions (open, close, collateral withdrawal, size change).
+
+### Position
+A leveraged trade. Key fields: owner, market, entry price, size (in target token), collateral (in collateral token), PnL, liquidation price.
+
+- **PDA derivation:** `["position", owner, pool, custody, side_byte]` where side_byte: Long=1, Short=2
+- **One position per market per side per wallet.** If you open a second trade on the same market+side, it merges into the existing position (increases size and averages entry price). You cannot hold independent positions at different entry prices for the same market+side. This affects grid trading and DCA strategies — multiple limit orders for the same market+side will merge into a single position as they fill.
+
+### Order Account
+Stores trigger orders (TP/SL) and limit orders per market per owner. Max 5 of each type per market.
+
+## Collateral & Leverage
+
+**Leverage** = position size USD / collateral USD. A $100 collateral at 5x leverage = $500 position size.
+
+**Collateral rules:**
+- **Minimum >$10 after fees** for positions that need limit orders, TP, or SL. Entry fees reduce collateral, so use $11-12+ minimum.
+- Long positions use the **target token** as collateral (SOL/SOL, ETH/ETH). USDC deposits are auto-swapped.
+- Short positions use **USDC** as collateral.
+- SOL positions use **JitoSOL** as underlying collateral on-chain.
+- `addCollateral` takes amounts in **token decimals**; `removeCollateral` takes amounts in **USD** (6 decimals).
+
+**Leverage limits (per custody):**
+- Standard: 1x to ~100x (`max_init_leverage`)
+- Degen Mode: up to 500x (`max_init_degen_leverage`)
+- Post-entry limit (`max_leverage`) is more lenient than initial limit
+
+## Fee Structure
+
+Fees are configured per custody and are ratio-dependent:
+
+| Fee Type | Typical Range | Notes |
+|----------|--------------|-------|
+| Open position | 4-8 BPS | Deducted from collateral at entry |
+| Close position | 4-8 BPS | Deducted from proceeds at exit |
+| Hourly borrow rate | Variable | Increases with pool utilization (Aave-style curve) |
+| Swap | 10-30 BPS | Ratio-dependent (underweight token = lower fee) |
+| LP deposit/withdrawal | 0-30 BPS | Incentivizes balanced pool composition |
+
+**Fee discounts:** Staking FLASH tokens (FAF) provides trading fee discounts. 6 stake levels with increasing benefits. Referral accounts provide rebates.
+
+## Degen Mode
+
+Higher-than-standard leverage on select assets (SOL, BTC, ETH):
+- Up to 500x initial leverage
+- Separate tracking via `degenSizeUsd` field on Position
+- Pool-level exposure cap (`Market.degen_exposure_usd`)
+- Higher minimum collateral requirement (`min_degen_collateral_usd`)
+- Not available for limit orders or trigger orders
+
+## Virtual Tokens
+
+Synthetic exposure to assets without actual token custody (forex, commodities, equities). The pool holds only USDC:
+1. Trader deposits USDC collateral
+2. Position tracks size/collateral in USD terms
+3. Pyth oracle provides reference price
+4. PnL settled in USDC based on price movement
+
+**Examples:** XAU (gold), XAG (silver), EUR, GBP, CRUDEOIL, USDJPY, TSLAr, NVDAr, SPYr
+
+**Identified by:** `Custody.is_virtual = true`
+
+## Order Types
+
+| Type | Execution | Collateral Requirement | Notes |
+|------|-----------|----------------------|-------|
+| Market | Immediate at oracle price + slippage | Any amount | Default order type |
+| Limit | When price hits target (keeper-executed) | >$10 after fees | Max 5 per market |
+| Take-Profit (TP) | When price hits profit target | >$10 after fees | Max 5 per market |
+| Stop-Loss (SL) | When price hits loss limit | >$10 after fees | Max 5 per market |
+
+Trigger orders (TP/SL) and limit orders are **executed by off-chain keepers**, not the position owner. Keeper latency may occur during high-volatility periods.
+
+## Composability
+
+The Composability Program (`FSWAPViR8ny5K96hezav8jynVubP2dJ2L7SbKzds2hwm`) enables atomic multi-step flows:
+- **Swap-and-Open:** Swap one token to collateral, then open a position — single transaction
+- **Close-and-Swap:** Close a position, then swap proceeds to another token
+- **Swap-and-Add-Collateral:** Swap a token and add it as position collateral
+- **Remove-Collateral-and-Swap:** Remove collateral and swap to another token
+
+## Oracle Pricing
+
+Flash Trade uses **Pyth Network** oracles:
+- **Pyth Lazer:** Low-latency price feed (200ms updates) — used for trade execution
+- **Pyth Hermes:** REST fallback for closed-market hours
+- **Internal backup oracle:** Secondary price source for safety
+
+**Important:** Pyth prices are **mainnet only**. Devnet returns stale/zero prices.
+
+Oracle configuration per custody:
+- `maxPriceAgeSec` — max staleness before `StaleOraclePrice` (6007)
+- `maxConfBps` — max confidence interval
+- `maxDivergenceBps` — max divergence between primary and backup oracles
+
+## Privilege Levels
+
+| Level | How to Get | Benefit |
+|-------|-----------|---------|
+| `None` | Default | Standard fees |
+| `Stake` | Stake FLASH tokens | Trading fee discount (varies by stake level) |
+| `Referral` | Create referral account | Fee rebates on referred trades |
+
+## Precision Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `BPS_DECIMALS` | 4 (10,000) | Basis points denominator |
+| `PRICE_DECIMALS` | 6 | Oracle price precision |
+| `USD_DECIMALS` | 6 | USD value precision ($1 = 1,000,000) |
+| `LP_DECIMALS` | 6 | FLP token precision |
+| `RATE_DECIMALS` | 9 | Borrow rate precision |
+
+## Program IDs
+
+| Program | Mainnet | Devnet |
+|---------|---------|--------|
+| Perpetuals | `FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn` | `FTPP4jEWW1n8s2FEccwVfS9KCPjpndaswg7Nkkuz4ER4` |
+| Composability | `FSWAPViR8ny5K96hezav8jynVubP2dJ2L7SbKzds2hwm` | `SWAP4AE4N1if9qKD7dgfQgmRBRv1CtWG8xDs4HP14ST` |
+| Pyth Lazer | `pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt` | — |
+
+## Global & Pool Permissions
+
+Both the `Perpetuals` global account and each `Pool` have 13 boolean permission flags:
+
+```
+allowSwap, allowAddLiquidity, allowRemoveLiquidity, allowOpenPosition,
+allowClosePosition, allowCollateralWithdrawal, allowSizeChange,
+allowLiquidation, allowLpStaking, allowFeeDistribution,
+allowUngatedTrading, allowFeeDiscounts, allowReferralRebates
+```
+
+When `allowUngatedTrading` is false, traders need an NFT or referral account to trade (error 6046: `InvalidAccess`).
+
+Markets also have individual `MarketPermissions`: `allowOpenPosition`, `allowClosePosition`, `allowCollateralWithdrawal`, `allowSizeChange`.

--- a/flash-trade/SKILL.md
+++ b/flash-trade/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: FlashTrade
+description: Flash Trade perpetual futures DEX developer integration on Solana. REST API, TypeScript SDK, MCP server, WebSocket streaming, transaction building, position management, trigger orders, liquidity provision. USE WHEN building on Flash Trade, integrating Flash Trade API, trading bot development, Flash Trade positions, Flash Trade liquidity, flash-sdk, flash perpetuals, flash perps.
+---
+
+# Flash Trade Developer Integration
+
+Flash Trade is a pool-to-peer perpetual futures DEX on Solana. Up to 100x leverage (500x Degen Mode), Pyth oracle pricing, virtual asset support (forex, commodities, equities).
+
+**Program ID (Mainnet):** `FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn`
+**Program ID (Devnet):** `FTPP4jEWW1n8s2FEccwVfS9KCPjpndaswg7Nkkuz4ER4`
+
+## Integration Surfaces (Choose Your Path)
+
+| Surface | Best For | Language | Complexity |
+|---------|----------|----------|------------|
+| **REST API** | Apps, bots, dashboards, any language | Any (HTTP) | Low |
+| **WebSocket** | Real-time position/order/price feeds | Any (WS) | Low |
+| **MCP Server** | AI agent integrations | MCP clients | Low |
+| **TypeScript SDK** | Direct on-chain control, custom programs | TypeScript | High |
+
+## Quick Start (REST API)
+
+```bash
+# Set your API base URL
+export FLASH_API_URL="https://flashapi.trade"
+
+# Get all markets
+curl $FLASH_API_URL/raw/markets
+
+# Get current prices
+curl $FLASH_API_URL/prices
+
+# Get wallet positions (enriched with PnL)
+curl $FLASH_API_URL/positions/owner/<WALLET_PUBKEY>
+
+# Open position (returns preview + unsigned transaction)
+curl -X POST $FLASH_API_URL/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG",
+    "owner": "<WALLET_PUBKEY>"
+  }'
+```
+
+## Intent Router
+
+| Intent | REST API Path | SDK Method | Reference |
+|--------|--------------|------------|-----------|
+| List markets/pools/custodies | `GET /raw/markets` | `PoolConfig.fromIdsByName()` | [ApiReference](ApiReference.md) |
+| Get oracle prices | `GET /prices` | `ViewHelper.getOraclePrice()` | [ApiReference](ApiReference.md) |
+| Get wallet positions + PnL | `GET /positions/owner/{owner}` | `ViewHelper.getPositionData()` | [ApiReference](ApiReference.md) |
+| Get wallet orders | `GET /orders/owner/{owner}` | — | [ApiReference](ApiReference.md) |
+| Open position | `POST /transaction-builder/open-position` | `client.openPosition()` | [TransactionFlow](TransactionFlow.md) |
+| Close position | `POST /transaction-builder/close-position` | `client.closePosition()` | [TransactionFlow](TransactionFlow.md) |
+| Reverse position | `POST /transaction-builder/reverse-position` | — | [TransactionFlow](TransactionFlow.md) |
+| Add/remove collateral | `POST /transaction-builder/add-collateral` | `client.addCollateral()` | [TransactionFlow](TransactionFlow.md) |
+| Place TP/SL | `POST /transaction-builder/place-trigger-order` | `client.placeTriggerOrder()` | [ApiReference](ApiReference.md) |
+| Place limit order | `POST /transaction-builder/open-position` (orderType=LIMIT) | `client.placeLimitOrder()` | [ApiReference](ApiReference.md) |
+| Preview fees/PnL | `POST /preview/*` | `ViewHelper.*` | [ApiReference](ApiReference.md) |
+| Stream positions live | `WS /owner/{owner}/ws` | — | [WebSocketStreaming](WebSocketStreaming.md) |
+| Pool stats (AUM, utilization) | `GET /pool-data` | `ViewHelper.getAssetsUnderManagement()` | [ApiReference](ApiReference.md) |
+| AI agent integration | MCP tools | — | [McpIntegration](McpIntegration.md) |
+
+## Critical Rules
+
+- **Minimum collateral >$10 after fees** for limit orders, TP, and SL. Use $11-12+ when TP/SL is needed.
+- **Blockhash expiry ~60s** — sign and submit transactions promptly after building.
+- **SOL positions use JitoSOL** as underlying collateral on-chain.
+- **Pyth prices are mainnet only** — devnet returns stale/zero.
+- **Max 5 trigger orders** (TP or SL) per market position.
+- **All amounts are UI format** (human-readable, e.g., "100.0") in API requests.
+- **No authentication required** — API is public. WebSocket has per-owner connection limits (5).
+- **One position per market per side per wallet.** Multiple orders for the same market+side merge into one position — you cannot hold independent positions at different entry prices.
+- **Wallet balances not available via Flash Trade API** — use Solana RPC `getTokenAccountsByOwner` to check balances before building transactions.
+
+## REST API Scope
+
+The REST API covers **trading operations only**:
+- Positions: open, close, reverse
+- Collateral: add, remove
+- Trigger orders: place, edit, cancel TP/SL
+- Previews: fees, margin, TP/SL projections
+- Data: markets, pools, prices, positions, orders, pool stats
+
+**Not available via REST API (requires [TypeScript SDK](SdkReference.md)):**
+- LP operations (add/remove liquidity, compounding)
+- FLP staking (deposit, unstake, collect rewards)
+- FLASH token staking
+- Limit order edit/cancel (SDK uses `editLimitOrder` with `sizeAmount=0` to cancel)
+
+**Implicit operations via REST (no dedicated endpoint):**
+- **Increase size:** Call `open-position` on a market where you already have a position — the API detects the existing position and calls `increaseSize` internally.
+- **Decrease size:** Call `close-position` with a partial `inputUsdUi` amount — the API calls `decreaseSize` internally.
+- **Place limit order:** Call `open-position` with `orderType: "LIMIT"` and `limitPrice` — the API builds a `placeLimitOrder` instruction.
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **SetupIntegration** | Getting started, setup, connect, configure | `Workflows/SetupIntegration.md` |
+| **QueryData** | Read markets, positions, prices, orders, pool data | `Workflows/QueryData.md` |
+| **BuildTransaction** | Open, close, reverse position, add/remove collateral, trigger orders | `Workflows/BuildTransaction.md` |
+| **ManagePositions** | Position lifecycle, monitoring, TP/SL management, risk | `Workflows/ManagePositions.md` |
+
+## Documentation Map
+
+| File | Content |
+|------|---------|
+| [ApiReference.md](ApiReference.md) | Complete REST API — all endpoints, request/response DTOs |
+| [TransactionFlow.md](TransactionFlow.md) | Build → sign → submit lifecycle with multi-language examples |
+| [WebSocketStreaming.md](WebSocketStreaming.md) | Real-time WebSocket streaming |
+| [McpIntegration.md](McpIntegration.md) | AI agent integration via MCP server |
+| [SdkReference.md](SdkReference.md) | TypeScript SDK (advanced, direct on-chain) |
+| [ProtocolConcepts.md](ProtocolConcepts.md) | Domain knowledge — pools, markets, fees, leverage, degen mode |
+| [ErrorReference.md](ErrorReference.md) | All 69 error codes with solutions |
+
+**Templates & Examples:**
+- [templates/api-trading-bot.py](templates/api-trading-bot.py) — Production Python trading bot (REST API)
+- [examples/api-quickstart/](examples/api-quickstart/README.md) — Quick start in cURL, TypeScript, Python
+- [examples/websocket-bot/](examples/websocket-bot/README.md) — Real-time position monitor (TypeScript + Python)
+
+## Examples
+
+**Example 1: Build a trading bot (REST API)**
+```
+User: "Build a Python bot that monitors SOL price and opens a long when it dips below $140"
+→ Invokes SetupIntegration workflow (API setup)
+→ Invokes QueryData workflow (price polling)
+→ Invokes BuildTransaction workflow (open position)
+→ References: ApiReference.md, TransactionFlow.md
+```
+
+**Example 2: Real-time position dashboard**
+```
+User: "Create a dashboard showing all my positions with live PnL"
+→ Invokes QueryData workflow (get positions)
+→ References: WebSocketStreaming.md (live updates), ApiReference.md (enriched positions)
+```
+
+**Example 3: AI agent that trades**
+```
+User: "Give my Claude agent the ability to trade on Flash Trade"
+→ Invokes SetupIntegration workflow (MCP server setup)
+→ References: McpIntegration.md
+```

--- a/flash-trade/SdkReference.md
+++ b/flash-trade/SdkReference.md
@@ -1,0 +1,323 @@
+# Flash Trade TypeScript SDK Reference
+
+Advanced integration path using `flash-sdk` for direct on-chain interaction. Use this when you need full control over transaction construction, custom program composition, or client-side computation.
+
+**For most integrations, the [REST API](ApiReference.md) is simpler.** Use the SDK when you need:
+- Client-side transaction building (no API dependency)
+- Custom instruction composition with other Solana programs
+- Direct on-chain view queries (ViewHelper)
+- Composability flows (swap-and-open, close-and-swap)
+
+## Setup
+
+```typescript
+import { PerpetualsClient, PoolConfig, Side, Privilege } from "flash-sdk";
+import { AnchorProvider, BN } from "@coral-xyz/anchor";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection("https://api.mainnet-beta.solana.com");
+const provider = new AnchorProvider(connection, wallet, { commitment: "processed" });
+
+// Load pool config (canonical source of truth for pool addresses)
+const poolConfig = PoolConfig.fromIdsByName("Crypto.1", "mainnet-beta");
+
+// Create client
+const client = new PerpetualsClient(
+  provider,
+  new PublicKey(poolConfig.programId),
+  new PublicKey(poolConfig.perpComposibilityProgramId),
+  new PublicKey(poolConfig.fbNftRewardProgramId),
+  new PublicKey(poolConfig.rewardDistributionProgram.programId),
+  { prioritizationFee: 10_000 },
+);
+
+// REQUIRED: Load address lookup tables before any transaction
+await client.loadAddressLookupTable(poolConfig);
+```
+
+**Critical:** Always call `loadAddressLookupTable()` before any operation. Transactions fail without ALTs.
+
+## Position Management
+
+### Open Position
+
+```typescript
+const { instructions, additionalSigners } = await client.openPosition(
+  "SOL",                                          // target symbol
+  "USDC",                                         // collateral symbol
+  { price: new BN(150_000_000), exponent: -6 },   // max entry price (slippage)
+  new BN(100_000_000),                             // 100 USDC collateral (6 decimals)
+  new BN(1_000_000_000),                           // 1 SOL size (9 decimals)
+  Side.Long,
+  poolConfig,
+  Privilege.None,
+);
+const sig = await client.sendTransaction(instructions, additionalSigners);
+```
+
+**Gotchas:**
+- `priceWithSlippage` = worst acceptable entry price. Above oracle for longs, below for shorts.
+- `sizeAmount` uses **target token decimals** (SOL=9, BTC=8), NOT USD.
+- Leverage = sizeUsd / collateralUsd. Enforced on-chain against custody limits.
+
+### Close Position
+
+```typescript
+const { instructions, additionalSigners } = await client.closePosition(
+  "SOL", "USDC",
+  { price: new BN(140_000_000), exponent: -6 },  // min exit price (below oracle for longs)
+  Side.Long, poolConfig, Privilege.None,
+);
+```
+
+### Increase / Decrease Size
+
+```typescript
+// Increase
+const { instructions } = await client.increaseSize(
+  "SOL", "USDC", priceWithSlippage,
+  new BN(500_000_000),  // add 0.5 SOL to size
+  Side.Long, poolConfig, Privilege.None,
+);
+
+// Decrease
+const { instructions } = await client.decreaseSize(
+  "SOL", "USDC", priceWithSlippage,
+  new BN(500_000_000),  // remove 0.5 SOL from size
+  Side.Long, poolConfig, Privilege.None,
+);
+```
+
+## Collateral
+
+```typescript
+// Add collateral (token decimals)
+const { instructions } = await client.addCollateral(
+  "SOL", "USDC",
+  new BN(50_000_000),  // 50 USDC (6 decimals)
+  Side.Long, poolConfig, Privilege.None,
+);
+
+// Remove collateral (USD value, 6 decimals)
+const { instructions } = await client.removeCollateral(
+  "SOL", "USDC",
+  new BN(25_000_000),  // $25 USD
+  Side.Long, poolConfig, Privilege.None,
+);
+```
+
+**Note:** `addCollateral` = token decimals. `removeCollateral` = USD decimals. This asymmetry is intentional.
+
+## Trigger Orders (TP/SL)
+
+```typescript
+// Place take-profit
+const { instructions } = await client.placeTriggerOrder(
+  "SOL", "USDC", Side.Long,
+  {
+    triggerPrice: { price: new BN(200_000_000), exponent: -6 },
+    deltaSizeAmount: new BN(500_000_000),  // close 0.5 SOL at trigger
+    isStopLoss: false,                      // false=TP, true=SL
+  },
+  poolConfig, Privilege.None,
+);
+
+// Edit trigger order
+await client.editTriggerOrder("SOL", "USDC", Side.Long, {
+  orderId: 0,  // index 0-4
+  triggerPrice: { price: new BN(210_000_000), exponent: -6 },
+  deltaSizeAmount: new BN(500_000_000),
+  isStopLoss: false,
+}, poolConfig, Privilege.None);
+
+// Cancel trigger order
+await client.cancelTriggerOrder("SOL", "USDC", Side.Long, {
+  orderId: 0,
+  isStopLoss: false,
+}, poolConfig, Privilege.None);
+```
+
+## Limit Orders
+
+```typescript
+// Place limit order
+const { instructions } = await client.placeLimitOrder(
+  "SOL", "USDC", Side.Long,
+  {
+    limitPrice: { price: new BN(140_000_000), exponent: -6 },
+    sizeAmount: new BN(1_000_000_000),
+    reserveAmount: new BN(100_000_000),         // USDC collateral reserved
+    stopLossPrice: { price: new BN(0), exponent: 0 },   // optional
+    takeProfitPrice: { price: new BN(0), exponent: 0 },  // optional
+  },
+  poolConfig, Privilege.None,
+);
+
+// Cancel limit order (set sizeAmount=0)
+await client.editLimitOrder("SOL", "USDC", Side.Long, {
+  orderId: 0,
+  limitPrice: { price: new BN(0), exponent: 0 },
+  sizeAmount: new BN(0),  // size=0 signals cancellation
+  stopLossPrice: { price: new BN(0), exponent: 0 },
+  takeProfitPrice: { price: new BN(0), exponent: 0 },
+}, poolConfig, Privilege.None);
+```
+
+## Composability (Atomic Multi-Step)
+
+```typescript
+// Swap token to collateral + open position (single transaction)
+const { instructions } = await client.swapAndOpenPosition(
+  "SOL",   // input token (will be swapped to collateral)
+  "ETH",   // target
+  "USDC",  // collateral
+  priceWithSlippage, inputAmount, sizeAmount,
+  Side.Long, poolConfig, Privilege.None,
+);
+
+// Close position + swap proceeds (single transaction)
+const { instructions } = await client.closeAndSwapPosition(
+  "ETH", "USDC", "SOL",  // target, collateral, output
+  priceWithSlippage, Side.Long, poolConfig, Privilege.None,
+);
+
+// Swap + add collateral
+const { instructions } = await client.swapAndAddCollateral(
+  "SOL", "ETH", "USDC", amountIn,
+  Side.Long, poolConfig, Privilege.None,
+);
+
+// Remove collateral + swap
+const { instructions } = await client.removeCollateralAndSwap(
+  "ETH", "USDC", "SOL", collateralDeltaUsd,
+  Side.Long, poolConfig, Privilege.None,
+);
+```
+
+## View Helpers (Read-Only Queries)
+
+On-chain view queries that return pricing and PnL data without modifying state:
+
+```typescript
+import { ViewHelper } from "flash-sdk";
+const viewHelper = new ViewHelper(connection, provider);
+
+// Entry price and fees for a potential position
+const { entryPrice, feeUsd } = await viewHelper.getEntryPriceAndFee(
+  "SOL", "USDC", collateralAmount, sizeAmount, Side.Long, poolConfig
+);
+
+// Exit price and fees for closing
+const { price, feeUsd } = await viewHelper.getExitPriceAndFee(
+  "SOL", "USDC", Side.Long, poolConfig
+);
+
+// Current PnL
+const { profit, loss } = await viewHelper.getPnl("SOL", "USDC", Side.Long, poolConfig);
+
+// Full position data
+const posData = await viewHelper.getPositionData("SOL", "USDC", Side.Long, poolConfig);
+
+// Liquidation price
+const liqPrice = await viewHelper.getLiquidationPrice("SOL", "USDC", Side.Long, poolConfig);
+
+// Whether position is currently liquidatable
+const isLiq = await viewHelper.getLiquidationState("SOL", "USDC", Side.Long, poolConfig);
+
+// Oracle price
+const oraclePrice = await viewHelper.getOraclePrice("SOL", poolConfig);
+
+// Swap quote
+const { amountOut, feeIn, feeOut } = await viewHelper.getSwapAmountAndFees(
+  "USDC", "SOL", amountIn, poolConfig
+);
+
+// LP token price
+const lpPrice = await viewHelper.getLpTokenPrice(poolConfig);
+
+// Pool AUM
+const aumUsd = await viewHelper.getAssetsUnderManagement(poolConfig);
+```
+
+## Liquidity Provision
+
+```typescript
+// Add liquidity and auto-stake
+const { instructions } = await client.addLiquidityAndStake(
+  "USDC", amountIn, minLpOut, poolConfig, Privilege.None,
+);
+
+// Add compounding liquidity (auto-reinvest rewards)
+const { instructions } = await client.addCompoundingLiquidity(
+  "USDC", amountIn, minCompoundingOut, poolConfig, Privilege.None,
+);
+
+// Remove liquidity
+const { instructions } = await client.removeLiquidity(
+  "USDC", lpAmountIn, minAmountOut, poolConfig, Privilege.None,
+);
+
+// FLP token price
+const price = await client.getCompoundingLPTokenPrice(poolConfig);
+```
+
+**Tip:** LP fees depend on pool token ratios. Depositing an underweight token gets a fee discount.
+
+## Staking
+
+```typescript
+// FLP staking
+await client.depositStake("USDC", depositAmount, poolConfig);
+await client.unstakeInstant("USDC", unstakeAmount, poolConfig);
+await client.unstakeRequest("USDC", unstakeAmount, poolConfig);
+await client.withdrawStake("USDC", poolConfig);
+await client.collectStakeFees("USDC", poolConfig);
+
+// FLASH token staking (fee discounts + referral rebates)
+await client.depositTokenStake(depositAmount, poolConfig);
+await client.collectTokenReward(poolConfig);
+await client.collectRevenue(poolConfig);
+await client.unstakeTokenInstant(amount, poolConfig);
+
+// Referrals
+await client.createReferral(poolConfig);
+await client.collectRebate(poolConfig);
+```
+
+## Compute Budget
+
+Flash Trade transactions need higher compute budgets:
+
+| Operation | Recommended CU |
+|-----------|---------------|
+| Open/Close Position | 600,000 |
+| Increase/Decrease Size | 600,000 |
+| Add/Remove Collateral | 400,000 |
+| Trigger/Limit Orders | 400,000 |
+| Swap-and-Open / Close-and-Swap | 800,000 |
+| Add/Remove Liquidity | 400,000 |
+
+```typescript
+import { ComputeBudgetProgram } from "@solana/web3.js";
+const cuIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 600_000 });
+```
+
+## Production Hardening
+
+1. **Always load ALTs** before any operation
+2. **Set priority fees** via `client.setPrioritizationFee(fee)`
+3. **Validate oracle freshness** — stale prices cause error 6007
+4. **Use slippage protection** — 1-3% from oracle for market orders
+5. **Monitor pool utilization** — high utilization = higher borrow rates + potential 6032
+6. **Handle keeper latency** — trigger/limit orders execute asynchronously
+7. **Check permissions** — pools and markets can disable operations
+8. **Use VersionedTransaction** — Flash Trade requires V0 transactions with ALTs
+9. **Use PoolConfig for discovery** — never hardcode pool addresses
+10. **Degen Mode guard** — check `PricingParams` before attempting >100x leverage
+
+## Resources
+
+- [flash-sdk on NPM](https://www.npmjs.com/package/flash-sdk)
+- [Flash Trade SDK GitHub](https://github.com/flash-trade/flash-trade-sdk)
+- [Flash Trade Docs](https://docs.flash.trade)
+- [Flash Trade Audit Reports](https://github.com/flash-trade/Audits)

--- a/flash-trade/TransactionFlow.md
+++ b/flash-trade/TransactionFlow.md
@@ -1,0 +1,771 @@
+# Transaction Flow
+
+How to build, sign, and submit transactions using the Flash Trade REST API.
+
+## Overview
+
+Every trade on Flash Trade follows a five-step flow. The API builds the transaction server-side; your client signs and submits it.
+
+```
+ 1. BUILD          POST /transaction-builder/{action}
+                   Send trade parameters, receive preview + unsigned tx
+                              |
+ 2. DECODE         Base64 decode -> deserialize VersionedTransaction (v0)
+                              |
+ 3. SIGN           Sign with wallet keypair (the tx is UNSIGNED)
+                              |
+ 4. SUBMIT         sendRawTransaction to Solana RPC
+                              |
+ 5. CONFIRM        Poll or subscribe for transaction confirmation
+```
+
+> **CRITICAL: Blockhash expiry.** The returned transaction contains a recent blockhash that expires in approximately 60 seconds. You must sign and submit promptly after receiving the transaction. If you delay, the blockhash will expire and the transaction will fail. See [Blockhash Expiry](#blockhash-expiry) for recovery strategies.
+
+## Step 1: Build Transaction
+
+POST to `/transaction-builder/{action}` with your trade parameters. The API returns preview data (fees, prices, leverage, liquidation levels) and a base64-encoded unsigned `VersionedTransaction`.
+
+### Available Actions
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/transaction-builder/open-position` | Open a new position (market or limit) |
+| `/transaction-builder/close-position` | Close or partially close a position |
+| `/transaction-builder/reverse-position` | Close + open opposite direction |
+| `/transaction-builder/add-collateral` | Add margin to reduce leverage |
+| `/transaction-builder/remove-collateral` | Withdraw margin to increase leverage |
+| `/transaction-builder/place-trigger-order` | Place a take-profit or stop-loss |
+| `/transaction-builder/edit-trigger-order` | Modify an existing TP/SL |
+| `/transaction-builder/cancel-trigger-order` | Cancel a single TP/SL |
+| `/transaction-builder/cancel-all-trigger-orders` | Cancel all TP/SL for a market+side |
+
+### Example Request: Open Position
+
+```bash
+curl -X POST https://flashapi.trade/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG",
+    "owner": "YourWa11etPubkeyHere1111111111111111111111111",
+    "slippagePercentage": "0.5"
+  }'
+```
+
+### Open Position Request Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inputTokenSymbol` | string | Yes | Token to pay with: `"USDC"`, `"SOL"`, etc. |
+| `outputTokenSymbol` | string | Yes | Market to trade: `"SOL"`, `"BTC"`, `"ETH"`, etc. |
+| `inputAmountUi` | string | Yes | Amount of input token in UI format, e.g. `"100.0"` |
+| `leverage` | number | Yes | Leverage multiplier, e.g. `5.0` |
+| `tradeType` | string | Yes | `"LONG"` or `"SHORT"` |
+| `owner` | string | No | Wallet pubkey. **Omit to get preview-only (no transaction built).** |
+| `orderType` | string | No | `"MARKET"` (default) or `"LIMIT"` |
+| `limitPrice` | string | No | Required for `LIMIT` orders. Trigger price in UI format. |
+| `slippagePercentage` | string | No | Default `"0.5"` (0.5%). Increase for volatile markets. |
+| `takeProfit` | string | No | TP trigger price in UI format. |
+| `stopLoss` | string | No | SL trigger price in UI format. |
+| `degenMode` | boolean | No | Enable higher leverage limits. |
+| `tradingFeeDiscountPercent` | number | No | Fee discount percentage if applicable. |
+
+### Open Position Response
+
+```json
+{
+  "newEntryPrice": "148.52",
+  "newLeverage": "4.95",
+  "newLiquidationPrice": "119.82",
+  "entryFee": "0.30",
+  "entryFeeBeforeDiscount": "0.30",
+  "openPositionFeePercent": "0.06",
+  "availableLiquidity": "12485023.50",
+  "youPayUsdUi": "100.00",
+  "youRecieveUsdUi": "495.00",
+  "marginFeePercentage": "0.0042",
+  "outputAmount": "3333333",
+  "outputAmountUi": "3.33",
+  "transactionBase64": "AQAAAA...long base64 string...AAAA==",
+  "takeProfitQuote": null,
+  "stopLossQuote": null,
+  "err": null
+}
+```
+
+### Response Fields Explained
+
+| Field | Description |
+|-------|-------------|
+| `newEntryPrice` | Entry price for the position in USD |
+| `newLeverage` | Effective leverage after fees |
+| `newLiquidationPrice` | Price at which the position gets liquidated |
+| `entryFee` | Fee charged in USD |
+| `openPositionFeePercent` | Fee as a percentage of position size |
+| `youPayUsdUi` | Total USD value of collateral deposited |
+| `youRecieveUsdUi` | Total position size in USD |
+| `marginFeePercentage` | Hourly borrow rate for leveraged positions |
+| `outputAmountUi` | Position size in the output token |
+| `transactionBase64` | Base64-encoded unsigned `VersionedTransaction`. **Only present when `owner` is provided.** |
+| `oldEntryPrice` / `oldLeverage` | Present when adding to an existing position |
+| `takeProfitQuote` | TP preview if `takeProfit` was specified |
+| `stopLossQuote` | SL preview if `stopLoss` was specified |
+| `err` | Error or warning message from the API, if any |
+
+### Close Position Response
+
+```json
+{
+  "receiveTokenSymbol": "USDC",
+  "receiveTokenAmountUi": "102.35",
+  "receiveTokenAmountUsdUi": "102.35",
+  "markPrice": "150.20",
+  "entryPrice": "148.52",
+  "existingSize": "495.00",
+  "newSize": "0.00",
+  "existingCollateral": "99.70",
+  "newCollateral": "0.00",
+  "existingLeverage": "4.95",
+  "newLeverage": "0.00",
+  "existingLiquidationPrice": "119.82",
+  "newLiquidationPrice": "0.00",
+  "settledPnl": "5.60",
+  "fees": "0.30",
+  "feesBeforeDiscount": "0.30",
+  "transactionBase64": "AQAAAA...base64...AAAA=="
+}
+```
+
+## Step 2: Decode and Sign
+
+The `transactionBase64` field contains a base64-encoded `VersionedTransaction` (v0 format, NOT legacy). You must:
+1. Base64-decode the string into raw bytes
+2. Deserialize into a `VersionedTransaction` object
+3. Sign with the wallet keypair
+
+> **Do NOT replace the blockhash.** The API may include pre-signed additional signers (e.g., ephemeral WSOL keypairs). Replacing the blockhash would invalidate those signatures.
+
+### TypeScript (@solana/web3.js)
+
+```typescript
+import { Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
+import bs58 from "bs58";
+
+// Decode the base64 transaction
+const txBytes = Buffer.from(response.transactionBase64, "base64");
+const transaction = VersionedTransaction.deserialize(txBytes);
+
+// Sign with your keypair
+const keypair = Keypair.fromSecretKey(/* your secret key bytes */);
+transaction.sign([keypair]);
+```
+
+> **Browser note:** `Buffer` is a Node.js API. In the browser, use `Uint8Array.from(atob(base64), c => c.charCodeAt(0))` instead. See the [Browser Wallet](#browser-wallet-solanawallet-adapter) section below for browser-compatible signing.
+
+### Browser Wallet (@solana/wallet-adapter)
+
+For React/Next.js apps where the user signs with their browser wallet (Phantom, Solflare, etc.):
+
+```typescript
+import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import { VersionedTransaction } from "@solana/web3.js";
+
+const { signTransaction } = useWallet();
+const { connection } = useConnection();
+
+// Decode the base64 transaction (browser-compatible — no Buffer needed)
+const txBytes = Uint8Array.from(atob(response.transactionBase64), c => c.charCodeAt(0));
+const transaction = VersionedTransaction.deserialize(txBytes);
+
+// Sign with the user's browser wallet (returns a new signed transaction)
+const signedTx = await signTransaction!(transaction);
+
+// Submit
+const signature = await connection.sendRawTransaction(signedTx.serialize(), {
+  skipPreflight: false,
+  maxRetries: 3,
+});
+
+// Confirm
+await connection.confirmTransaction(signature, "confirmed");
+```
+
+**Key differences from server-side signing:**
+- Browser wallets use `wallet.signTransaction(tx)` which returns a new signed transaction — NOT `tx.sign([keypair])`
+- You do NOT have access to the private key — the wallet extension handles signing
+- Use `Uint8Array.from(atob(...))` instead of `Buffer.from(...)` for browser compatibility
+- The `signTransaction` function may throw if the user rejects the signing prompt
+
+### Python (solders)
+
+```python
+import base64
+from solders.transaction import VersionedTransaction
+from solders.keypair import Keypair
+
+# Decode the base64 transaction
+tx_bytes = base64.b64decode(response["transactionBase64"])
+transaction = VersionedTransaction.from_bytes(tx_bytes)
+
+# Sign with your keypair
+keypair = Keypair.from_bytes(secret_key_bytes)
+signed_tx = VersionedTransaction(transaction.message, [keypair])
+```
+
+> **Note:** The `solders` library is the modern, recommended way to handle Solana transactions in Python. It provides native Rust-backed types that are significantly faster than the older `solana-py` library. Install with `pip install solders`.
+
+### cURL / Shell
+
+For shell-based workflows, you can decode the base64 and use a signing tool:
+
+```bash
+# Save the base64 transaction to a file
+echo "$TRANSACTION_BASE64" | base64 --decode > unsigned_tx.bin
+
+# Sign using solana CLI (if your keypair is configured)
+# Note: The Solana CLI does not natively sign pre-built VersionedTransactions.
+# You will need a helper script or tool. See the Complete Examples section.
+```
+
+## Step 3: Submit to Solana
+
+After signing, serialize the transaction and send it to a Solana RPC node.
+
+### TypeScript
+
+```typescript
+const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+
+// Send the signed transaction
+const signature = await connection.sendRawTransaction(transaction.serialize(), {
+  skipPreflight: false,
+  preflightCommitment: "confirmed",
+});
+
+console.log(`Transaction sent: ${signature}`);
+console.log(`Explorer: https://solscan.io/tx/${signature}`);
+```
+
+### Python
+
+```python
+from solders.rpc.requests import SendRawTransaction
+from solana.rpc.api import Client
+
+client = Client("https://api.mainnet-beta.solana.com")
+
+# Send the signed transaction
+result = client.send_raw_transaction(
+    bytes(signed_tx),
+    opts={"skip_preflight": False, "preflight_commitment": "confirmed"},
+)
+signature = str(result.value)
+print(f"Transaction sent: {signature}")
+print(f"Explorer: https://solscan.io/tx/{signature}")
+```
+
+### Confirmation Strategies
+
+After sending, confirm the transaction landed on-chain:
+
+```typescript
+// Strategy 1: confirmTransaction (recommended)
+const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+const confirmation = await connection.confirmTransaction(
+  {
+    signature,
+    blockhash,
+    lastValidBlockHeight,
+  },
+  "confirmed"
+);
+
+if (confirmation.value.err) {
+  console.error("Transaction failed on-chain:", confirmation.value.err);
+} else {
+  console.log("Transaction confirmed!");
+}
+
+// Strategy 2: Poll with getSignatureStatuses (for more control)
+let status = null;
+while (!status) {
+  const response = await connection.getSignatureStatuses([signature]);
+  status = response.value[0];
+  if (!status) await new Promise((r) => setTimeout(r, 1000));
+}
+```
+
+For production use, implement retry logic with a timeout based on `lastValidBlockHeight`. If the block height is exceeded without confirmation, the transaction has expired and you must rebuild it.
+
+## Preview-Only Mode
+
+To get just the preview data (fees, entry price, leverage, liquidation price) without building a transaction, **omit the `owner` field** from the request.
+
+```bash
+curl -X POST https://flashapi.trade/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG"
+  }'
+```
+
+The response will contain all preview fields (`newEntryPrice`, `newLeverage`, `entryFee`, etc.) but `transactionBase64` will be `null`.
+
+This is useful for:
+- Displaying quotes to users before they commit
+- Polling for real-time price/fee updates (the Flash Trade UI polls every 5 seconds)
+- Calculating position parameters without wallet connection
+- Building trading UIs where the user reviews before signing
+
+## Blockhash Expiry
+
+Solana transactions include a `recentBlockhash` that expires after approximately 60 seconds (~150 slots). If the blockhash expires before the transaction is confirmed, it will be rejected by the network.
+
+### Symptoms
+
+- Error: `"Blockhash not found"`
+- Error: `"block height exceeded"`
+- The transaction simply never confirms
+
+### Prevention
+
+1. **Sign and submit immediately** after receiving the transaction from the API. Do not insert delays, user prompts, or additional network calls between receiving the transaction and submitting it.
+2. **Do not cache transactions.** Always request a fresh transaction right before you need to submit it.
+3. **Show the preview first, then build the transaction.** Use preview-only mode (omit `owner`) to show the user fees and prices. When they approve, make a second request with `owner` included, and submit immediately.
+
+### Recovery
+
+If you encounter a blockhash expiry error:
+
+```typescript
+async function executeWithRetry(buildTransaction: () => Promise<Response>, maxRetries = 2) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await buildTransaction();
+    const data = await response.json();
+
+    if (!data.transactionBase64) {
+      throw new Error(data.err || "No transaction returned");
+    }
+
+    const txBytes = Buffer.from(data.transactionBase64, "base64");
+    const transaction = VersionedTransaction.deserialize(txBytes);
+    transaction.sign([keypair]);
+
+    try {
+      const signature = await connection.sendRawTransaction(transaction.serialize(), {
+        skipPreflight: false,
+        preflightCommitment: "confirmed",
+      });
+
+      const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+      const confirmation = await connection.confirmTransaction(
+        { signature, blockhash, lastValidBlockHeight },
+        "confirmed"
+      );
+
+      if (confirmation.value.err) {
+        throw new Error(`On-chain failure: ${JSON.stringify(confirmation.value.err)}`);
+      }
+
+      return signature;
+    } catch (error: any) {
+      const isExpired =
+        error.message?.includes("Blockhash not found") ||
+        error.message?.includes("block height exceeded");
+
+      if (isExpired && attempt < maxRetries) {
+        console.warn(`Blockhash expired, rebuilding transaction (attempt ${attempt + 2}/${maxRetries + 1})`);
+        continue; // Re-fetch a fresh transaction from the API
+      }
+      throw error;
+    }
+  }
+}
+```
+
+## Error Handling
+
+### Common Transaction Errors
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| `Blockhash not found` | Transaction took too long to submit (~60s) | Rebuild the transaction and submit immediately |
+| `block height exceeded` | Same as above, caught during confirmation | Rebuild the transaction and submit immediately |
+| `Cannot sign with non signer key` | Transaction was built for a different wallet than the signing keypair | Rebuild with the correct `owner` matching your keypair |
+| `Insufficient funds` | Wallet does not have enough of the input token | Check balance, reduce amount |
+| `Transaction simulation failed` | On-chain program rejected the transaction | Check the inner error logs for details (insufficient liquidity, invalid parameters, etc.) |
+| `Custom program error: 0x...` | Flash Trade program error | Decode the hex error code against the Flash Trade IDL |
+
+### API-Level Errors
+
+The `err` field in the response may contain warnings even when a transaction is returned:
+
+```json
+{
+  "transactionBase64": "AQAAAA...AAAA==",
+  "err": "Position size exceeds available liquidity for this market"
+}
+```
+
+Always check the `err` field before proceeding. Some warnings are informational (the transaction may still succeed), while others indicate the transaction will fail on-chain.
+
+### Signer Mismatch
+
+The most common integration error is a signer mismatch. The `owner` field in your request must exactly match the public key of the keypair you sign with. If they differ, the transaction will fail with `Cannot sign with non signer key`.
+
+```typescript
+// Ensure owner matches your signing keypair
+const owner = keypair.publicKey.toBase58();
+const response = await fetch(`${API_URL}/transaction-builder/open-position`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    inputTokenSymbol: "USDC",
+    outputTokenSymbol: "SOL",
+    inputAmountUi: "100.0",
+    leverage: 5.0,
+    tradeType: "LONG",
+    owner, // Must match the signing keypair
+  }),
+});
+```
+
+## Complete Examples
+
+### TypeScript (Full Working Example)
+
+```typescript
+import { Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
+import fs from "fs";
+
+// --- Configuration ---
+const API_URL = "https://flashapi.trade";
+const RPC_URL = "https://api.mainnet-beta.solana.com";
+
+// Load keypair from file (standard Solana CLI format)
+const keypairData = JSON.parse(fs.readFileSync("~/.config/solana/id.json", "utf-8"));
+const keypair = Keypair.fromSecretKey(Uint8Array.from(keypairData));
+const owner = keypair.publicKey.toBase58();
+
+const connection = new Connection(RPC_URL, "confirmed");
+
+// --- Step 1: Build the transaction ---
+async function openPosition() {
+  const response = await fetch(`${API_URL}/transaction-builder/open-position`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      inputTokenSymbol: "USDC",
+      outputTokenSymbol: "SOL",
+      inputAmountUi: "50.0",
+      leverage: 3.0,
+      tradeType: "LONG",
+      owner,
+      slippagePercentage: "0.5",
+    }),
+  });
+
+  const data = await response.json();
+
+  // --- Check for errors ---
+  if (data.err) {
+    console.warn("API warning:", data.err);
+  }
+  if (!data.transactionBase64) {
+    throw new Error("No transaction returned. Check the err field.");
+  }
+
+  // --- Display preview ---
+  console.log("=== Trade Preview ===");
+  console.log(`Entry Price:      $${data.newEntryPrice}`);
+  console.log(`Position Size:    $${data.youRecieveUsdUi} (${data.outputAmountUi} SOL)`);
+  console.log(`Collateral:       $${data.youPayUsdUi}`);
+  console.log(`Leverage:         ${data.newLeverage}x`);
+  console.log(`Liquidation:      $${data.newLiquidationPrice}`);
+  console.log(`Entry Fee:        $${data.entryFee} (${data.openPositionFeePercent}%)`);
+  console.log(`Hourly Borrow:    ${data.marginFeePercentage}%`);
+
+  // --- Step 2: Decode and sign ---
+  const txBytes = Buffer.from(data.transactionBase64, "base64");
+  const transaction = VersionedTransaction.deserialize(txBytes);
+  transaction.sign([keypair]);
+
+  // --- Step 3: Submit ---
+  const signature = await connection.sendRawTransaction(transaction.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: "confirmed",
+  });
+
+  console.log(`\nTransaction sent: ${signature}`);
+  console.log(`Explorer: https://solscan.io/tx/${signature}`);
+
+  // --- Step 4: Confirm ---
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+  const confirmation = await connection.confirmTransaction(
+    { signature, blockhash, lastValidBlockHeight },
+    "confirmed"
+  );
+
+  if (confirmation.value.err) {
+    throw new Error(`Transaction failed on-chain: ${JSON.stringify(confirmation.value.err)}`);
+  }
+
+  console.log("Transaction confirmed!");
+  return signature;
+}
+
+openPosition().catch(console.error);
+```
+
+### Python (Full Working Example)
+
+```python
+"""
+Flash Trade transaction flow using solders + httpx.
+
+Install dependencies:
+    pip install solders httpx
+"""
+
+import base64
+import json
+import httpx
+from solders.keypair import Keypair
+from solders.transaction import VersionedTransaction
+from solana.rpc.api import Client
+
+# --- Configuration ---
+API_URL = "https://flashapi.trade"
+RPC_URL = "https://api.mainnet-beta.solana.com"
+
+# Load keypair from file (standard Solana CLI JSON format)
+with open("~/.config/solana/id.json") as f:
+    secret_key_bytes = bytes(json.load(f))
+keypair = Keypair.from_bytes(secret_key_bytes)
+owner = str(keypair.pubkey())
+
+client = Client(RPC_URL)
+
+
+def open_position():
+    # --- Step 1: Build the transaction ---
+    response = httpx.post(
+        f"{API_URL}/transaction-builder/open-position",
+        json={
+            "inputTokenSymbol": "USDC",
+            "outputTokenSymbol": "SOL",
+            "inputAmountUi": "50.0",
+            "leverage": 3.0,
+            "tradeType": "LONG",
+            "owner": owner,
+            "slippagePercentage": "0.5",
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    # --- Check for errors ---
+    if data.get("err"):
+        print(f"API warning: {data['err']}")
+    if not data.get("transactionBase64"):
+        raise RuntimeError("No transaction returned. Check the err field.")
+
+    # --- Display preview ---
+    print("=== Trade Preview ===")
+    print(f"Entry Price:      ${data['newEntryPrice']}")
+    print(f"Position Size:    ${data['youRecieveUsdUi']} ({data['outputAmountUi']} SOL)")
+    print(f"Collateral:       ${data['youPayUsdUi']}")
+    print(f"Leverage:         {data['newLeverage']}x")
+    print(f"Liquidation:      ${data['newLiquidationPrice']}")
+    print(f"Entry Fee:        ${data['entryFee']} ({data['openPositionFeePercent']}%)")
+    print(f"Hourly Borrow:    {data['marginFeePercentage']}%")
+
+    # --- Step 2: Decode and sign ---
+    tx_bytes = base64.b64decode(data["transactionBase64"])
+    unsigned_tx = VersionedTransaction.from_bytes(tx_bytes)
+
+    # solders requires constructing a new VersionedTransaction with signers
+    signed_tx = VersionedTransaction(unsigned_tx.message, [keypair])
+
+    # --- Step 3: Submit ---
+    result = client.send_raw_transaction(bytes(signed_tx))
+    signature = str(result.value)
+
+    print(f"\nTransaction sent: {signature}")
+    print(f"Explorer: https://solscan.io/tx/{signature}")
+
+    # --- Step 4: Confirm ---
+    # solana-py's send_raw_transaction with default opts will preflight check.
+    # For explicit confirmation:
+    confirmation = client.confirm_transaction(
+        result.value,
+        commitment="confirmed",
+    )
+
+    if confirmation.value[0].err:
+        raise RuntimeError(f"Transaction failed on-chain: {confirmation.value[0].err}")
+
+    print("Transaction confirmed!")
+    return signature
+
+
+if __name__ == "__main__":
+    open_position()
+```
+
+### cURL + Node.js Signing Script
+
+For environments where you want to use cURL for the API call and a minimal script for signing:
+
+```bash
+#!/bin/bash
+# flash-trade.sh — Build, sign, and submit a Flash Trade transaction
+
+API_URL="https://flashapi.trade"
+RPC_URL="https://api.mainnet-beta.solana.com"
+KEYPAIR_PATH="$HOME/.config/solana/id.json"
+
+# Step 1: Build the transaction via API
+echo "Building transaction..."
+RESPONSE=$(curl -s -X POST "$API_URL/transaction-builder/open-position" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "50.0",
+    "leverage": 3.0,
+    "tradeType": "LONG",
+    "owner": "'"$WALLET_PUBKEY"'",
+    "slippagePercentage": "0.5"
+  }')
+
+# Extract preview data
+echo "=== Trade Preview ==="
+echo "$RESPONSE" | jq -r '"Entry Price:   $\(.newEntryPrice)
+Position Size: $\(.youRecieveUsdUi)
+Collateral:    $\(.youPayUsdUi)
+Leverage:      \(.newLeverage)x
+Liq Price:     $\(.newLiquidationPrice)
+Entry Fee:     $\(.entryFee) (\(.openPositionFeePercent)%)"'
+
+# Extract the base64 transaction
+TX_BASE64=$(echo "$RESPONSE" | jq -r '.transactionBase64')
+if [ "$TX_BASE64" = "null" ] || [ -z "$TX_BASE64" ]; then
+  echo "ERROR: No transaction returned"
+  echo "$RESPONSE" | jq -r '.err // "Unknown error"'
+  exit 1
+fi
+
+# Step 2 & 3: Sign and submit using a Node.js one-liner
+echo ""
+echo "Signing and submitting..."
+node -e "
+const { Connection, Keypair, VersionedTransaction } = require('@solana/web3.js');
+const fs = require('fs');
+
+(async () => {
+  const keypair = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(fs.readFileSync('$KEYPAIR_PATH', 'utf-8')))
+  );
+  const tx = VersionedTransaction.deserialize(
+    Buffer.from('$TX_BASE64', 'base64')
+  );
+  tx.sign([keypair]);
+
+  const connection = new Connection('$RPC_URL', 'confirmed');
+  const sig = await connection.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: 'confirmed',
+  });
+
+  console.log('Signature:', sig);
+  console.log('Explorer: https://solscan.io/tx/' + sig);
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
+  const conf = await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    'confirmed'
+  );
+
+  if (conf.value.err) {
+    console.error('FAILED:', JSON.stringify(conf.value.err));
+    process.exit(1);
+  }
+  console.log('Confirmed!');
+})();
+"
+```
+
+### Close Position Example (TypeScript)
+
+```typescript
+import { Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
+import fs from "fs";
+
+const API_URL = "https://flashapi.trade";
+const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+
+const keypairData = JSON.parse(fs.readFileSync("~/.config/solana/id.json", "utf-8"));
+const keypair = Keypair.fromSecretKey(Uint8Array.from(keypairData));
+
+async function closePosition(positionKey: string, sizeUsd: string) {
+  // Step 1: Build close transaction
+  const response = await fetch(`${API_URL}/transaction-builder/close-position`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      positionKey,
+      inputUsdUi: sizeUsd,        // Full position size for full close
+      withdrawTokenSymbol: "USDC", // Token to receive proceeds in
+      slippagePercentage: "0.5",
+    }),
+  });
+
+  const data = await response.json();
+
+  console.log("=== Close Preview ===");
+  console.log(`Mark Price:    $${data.markPrice}`);
+  console.log(`Entry Price:   $${data.entryPrice}`);
+  console.log(`PnL:           $${data.settledPnl}`);
+  console.log(`Receive:       ${data.receiveTokenAmountUi} ${data.receiveTokenSymbol} ($${data.receiveTokenAmountUsdUi})`);
+  console.log(`Fees:          $${data.fees}`);
+
+  if (!data.transactionBase64) {
+    throw new Error(data.err || "No transaction returned");
+  }
+
+  // Steps 2-4: Decode, sign, submit, confirm
+  const tx = VersionedTransaction.deserialize(Buffer.from(data.transactionBase64, "base64"));
+  tx.sign([keypair]);
+
+  const signature = await connection.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: "confirmed",
+  });
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+  await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
+
+  console.log(`\nPosition closed: https://solscan.io/tx/${signature}`);
+}
+
+// Usage: pass the position account pubkey and USD amount to close
+closePosition("YourPositionPubkey111111111111111111111111111", "495.00");
+```
+
+## Key Notes
+
+- **VersionedTransaction (v0), NOT legacy.** The API returns v0 transactions. Use `VersionedTransaction.deserialize()`, not `Transaction.from()`.
+- **Transactions are unsigned.** The API builds the transaction but does not sign it. Your client must sign before submitting.
+- **Do NOT modify the blockhash.** The transaction may contain pre-signed additional signers (e.g., ephemeral WSOL token accounts). Changing the blockhash would invalidate their signatures.
+- **Amounts are in UI format.** Use human-readable strings like `"100.0"`, not native lamport/smallest-unit integers.
+- **SOL positions use JitoSOL** as underlying collateral on-chain. This is handled automatically by the API.
+- **Minimum $11 for TP/SL.** If you plan to set take-profit or stop-loss, use at least $11-12 input amount. Entry fees reduce collateral, and TP/SL orders require >$10 collateral after fees.
+- **`youRecieveUsdUi` is intentionally misspelled** in the API response (matches the Rust backend field name). Do not attempt to correct it.

--- a/flash-trade/WebSocketStreaming.md
+++ b/flash-trade/WebSocketStreaming.md
@@ -1,0 +1,597 @@
+# WebSocket Streaming
+
+Real-time streaming of positions, orders, and prices from the Flash Trade Builder API.
+
+---
+
+## 1. WebSocket Endpoint — Positions & Orders
+
+### Connection
+
+```
+GET /owner/{owner}/ws
+```
+
+**URL construction:** Replace the `http(s)://` scheme of the Builder API endpoint with `ws(s)://`, then append the path.
+
+```
+wss://flashapi.trade/owner/7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU/ws?includePnlInLeverageDisplay=true&updateIntervalMs=1000
+```
+
+The server responds with HTTP `101 Switching Protocols` to upgrade the connection.
+
+### Path Parameters
+
+| Parameter | Type   | Required | Description                                    |
+|-----------|--------|----------|------------------------------------------------|
+| `owner`   | string | Yes      | Owner wallet public key (base58-encoded)       |
+
+### Query Parameters
+
+| Parameter                       | Type   | Required | Default | Description                                                      |
+|---------------------------------|--------|----------|---------|------------------------------------------------------------------|
+| `includePnlInLeverageDisplay`   | bool   | Yes      | --      | When `true`, PnL is factored into the leverage calculation       |
+| `updateIntervalMs`              | u64    | No       | `1000`  | How often the server recomputes position data (ms). Clamped to `[100, 10000]` |
+
+### Message Types
+
+The server sends two types of JSON text messages, distinguished by the `type` field:
+
+| `type`        | When sent                                                                                                  |
+|---------------|------------------------------------------------------------------------------------------------------------|
+| `"positions"` | On every recomputation interval (price-driven). Sent immediately on connect, then at `updateIntervalMs`.   |
+| `"orders"`    | Only when an on-chain order event fires (limit/TP/SL created, cancelled, or modified). Also sent on connect. |
+
+Both messages are **full snapshots** (the complete array of all current positions or orders for the owner), not incremental diffs.
+
+### Message Format
+
+#### Positions Message
+
+```json
+{
+  "type": "positions",
+  "data": [
+    {
+      "key": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+      "positionAccountData": "qryP5HpA99AAAA...",
+      "sideUi": "Long",
+      "marketSymbol": "SOL",
+      "collateralSymbol": "USDC",
+      "entryOraclePrice": {
+        "price": "14852000000",
+        "exponent": "-8",
+        "confidence": "0",
+        "timestamp": "1707900000"
+      },
+      "entryPriceUi": "148.52",
+      "sizeAmountUi": "3.37",
+      "sizeAmountUiKmb": "3.37",
+      "sizeUsdUi": "500.00",
+      "collateralAmountUi": "100.00",
+      "collateralAmountUiKmb": "100.00",
+      "collateralUsdUi": "100.00",
+      "isDegen": false,
+      "pnl": {
+        "profitUsd": "12.50",
+        "lossUsd": "0.00",
+        "exitFeeUsd": "0.40",
+        "borrowFeeUsd": "0.15",
+        "exitFeeAmount": "0.002700",
+        "borrowFeeAmount": "0.001012",
+        "priceImpactUsd": "0",
+        "priceImpactSet": false
+      },
+      "pnlWithFeeUsdUi": "-15.30",
+      "pnlPercentageWithFee": "-15.30",
+      "pnlWithoutFeeUsdUi": "-14.75",
+      "pnlPercentageWithoutFee": "-14.75",
+      "liquidationPriceUi": "120.30",
+      "leverageUi": "5.00"
+    }
+  ]
+}
+```
+
+**Field reference — `PositionTableDataUiDto`:**
+
+| Field                       | Type             | Description                                                                 |
+|-----------------------------|------------------|-----------------------------------------------------------------------------|
+| `key`                       | `string`         | Position account pubkey (base58)                                            |
+| `positionAccountData`       | `string`         | Raw Anchor-encoded position account data (base64). Decode with Anchor IDL.  |
+| `sideUi`                    | `string?`        | `"Long"` or `"Short"`                                                       |
+| `marketSymbol`              | `string?`        | Target market token symbol (e.g. `"SOL"`, `"BTC"`, `"ETH"`)                |
+| `collateralSymbol`          | `string?`        | Collateral token symbol (e.g. `"USDC"`, `"SOL"`)                           |
+| `entryOraclePrice`          | `OraclePriceDto?`| Oracle price at entry (see sub-table below)                                 |
+| `entryPriceUi`              | `string?`        | Entry price, human-readable                                                 |
+| `sizeAmountUi`              | `string?`        | Position size in target token (UI decimals)                                 |
+| `sizeAmountUiKmb`           | `string?`        | Size formatted with K/M/B abbreviations                                     |
+| `sizeUsdUi`                 | `string?`        | Position size in USD                                                        |
+| `collateralAmountUi`        | `string?`        | Collateral amount in collateral token                                       |
+| `collateralAmountUiKmb`     | `string?`        | Collateral formatted with K/M/B abbreviations                               |
+| `collateralUsdUi`           | `string?`        | Collateral amount in USD                                                    |
+| `isDegen`                   | `bool?`          | Whether position uses degen (high-leverage) mode                            |
+| `pnl`                       | `PnlDto?`        | Breakdown of profit, loss, and fees (see sub-table below)                   |
+| `pnlWithFeeUsdUi`           | `string?`        | PnL after fees in USD                                                       |
+| `pnlPercentageWithFee`      | `string?`        | PnL percentage after fees                                                   |
+| `pnlWithoutFeeUsdUi`        | `string?`        | PnL before fees in USD                                                      |
+| `pnlPercentageWithoutFee`   | `string?`        | PnL percentage before fees                                                  |
+| `liquidationPriceUi`        | `string?`        | Estimated liquidation price                                                 |
+| `leverageUi`                | `string?`        | Current effective leverage                                                  |
+
+**`OraclePriceDto` fields:**
+
+| Field        | Type     | Description                                          |
+|--------------|----------|------------------------------------------------------|
+| `price`      | `string` | Raw integer price (e.g. `"14852000000"`)             |
+| `exponent`   | `string` | Power-of-10 exponent (e.g. `"-8"`)                   |
+| `confidence` | `string` | Confidence interval (always `"0"` for Lazer prices)  |
+| `timestamp`  | `string` | Unix timestamp in seconds                            |
+
+To compute the human-readable price: `price * 10^exponent` (e.g. `14852000000 * 10^-8 = 148.52`).
+
+**`PnlDto` fields:**
+
+| Field             | Type     | Description                                    |
+|-------------------|----------|------------------------------------------------|
+| `profitUsd`       | `string` | Unrealized profit in USD (0 if losing)         |
+| `lossUsd`         | `string` | Unrealized loss in USD (0 if profiting)        |
+| `exitFeeUsd`      | `string` | Estimated exit (close) fee in USD              |
+| `borrowFeeUsd`    | `string` | Accrued borrow fee in USD                      |
+| `exitFeeAmount`   | `string` | Exit fee in position's target token            |
+| `borrowFeeAmount` | `string` | Borrow fee in position's target token          |
+| `priceImpactUsd`  | `string` | Price impact fee in USD                        |
+| `priceImpactSet`  | `bool`   | Whether price impact has been applied          |
+
+**Note:** Optional fields (marked `?`) are omitted from the JSON when `null` (via `skip_serializing_if`). Always check for their presence before accessing.
+
+#### Orders Message
+
+```json
+{
+  "type": "orders",
+  "data": [
+    {
+      "key": "9bGqYz4YXMF1dW2TLpJe5gR3vUqAc7GnhQWcJ4TkVd8K",
+      "orderAccountData": "Ag4OAAAAAAA...",
+      "limitOrders": [
+        {
+          "market": "3Xm4rcMEqGANX2PixhGqFdEcEn8xSMRN1G8SAaLnBkwP",
+          "orderId": 0,
+          "sideUi": "Long",
+          "symbol": "SOL",
+          "reserveSymbol": "USDC",
+          "reserveAmountUi": "100.00",
+          "reserveAmountUsdUi": "100.00",
+          "sizeAmountUi": "0.67",
+          "sizeAmountUiKmb": "0.67",
+          "sizeUsdUi": "500.00",
+          "collateralAmountUi": "100.00",
+          "collateralAmountUiKmb": "100.00",
+          "collateralAmountUsdUi": "100.00",
+          "entryOraclePrice": {
+            "price": "14852000000",
+            "exponent": "-8",
+            "confidence": "0",
+            "timestamp": "1707900000"
+          },
+          "entryPriceUi": "148.52",
+          "leverageUi": "5.00",
+          "liquidationPriceUi": "120.30",
+          "limitTakeProfitPriceUi": "-",
+          "limitStopLossPriceUi": "-",
+          "receiveTokenSymbol": "USDC",
+          "reserveTokenSymbol": "USDC"
+        }
+      ],
+      "takeProfitOrders": [
+        {
+          "market": "3Xm4rcMEqGANX2PixhGqFdEcEn8xSMRN1G8SAaLnBkwP",
+          "orderId": 0,
+          "sideUi": "Long",
+          "symbol": "SOL",
+          "receiveTokenSymbol": "USDC",
+          "sizeAmountUi": "0.67",
+          "sizeAmountUiKmb": "0.67",
+          "sizeUsdUi": "500.00",
+          "type": "TP",
+          "triggerPriceUi": "160.00",
+          "leverage": ""
+        }
+      ],
+      "stopLossOrders": [
+        {
+          "market": "3Xm4rcMEqGANX2PixhGqFdEcEn8xSMRN1G8SAaLnBkwP",
+          "orderId": 0,
+          "sideUi": "Long",
+          "symbol": "SOL",
+          "receiveTokenSymbol": "USDC",
+          "sizeAmountUi": "0.67",
+          "sizeAmountUiKmb": "0.67",
+          "sizeUsdUi": "500.00",
+          "type": "SL",
+          "triggerPriceUi": "130.00",
+          "leverage": ""
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Field reference — `OrderDataUiDto`:**
+
+| Field              | Type                       | Description                                                   |
+|--------------------|----------------------------|---------------------------------------------------------------|
+| `key`              | `string`                   | Order account pubkey (base58)                                 |
+| `orderAccountData` | `string`                   | Raw Anchor-encoded order account data (base64)                |
+| `limitOrders`      | `LimitOrderUiDto[]`        | Active limit orders (see below)                               |
+| `takeProfitOrders` | `TakeProfitOrderUiDto[]`   | Active take-profit trigger orders                             |
+| `stopLossOrders`   | `StopLossOrderUiDto[]`     | Active stop-loss trigger orders                               |
+
+**`LimitOrderUiDto` fields:**
+
+| Field                     | Type             | Description                                        |
+|---------------------------|------------------|----------------------------------------------------|
+| `market`                  | `string`         | Market account pubkey                              |
+| `orderId`                 | `number`         | Index within the order account                     |
+| `sideUi`                  | `string`         | `"Long"` or `"Short"`                              |
+| `symbol`                  | `string`         | Target market symbol                               |
+| `reserveSymbol`           | `string`         | Reserve token symbol                               |
+| `reserveAmountUi`         | `string`         | Reserve amount (UI format)                         |
+| `reserveAmountUsdUi`      | `string`         | Reserve amount in USD                              |
+| `sizeAmountUi`            | `string`         | Size in target token                               |
+| `sizeAmountUiKmb`         | `string`         | Size with K/M/B abbreviation                       |
+| `sizeUsdUi`               | `string`         | Size in USD                                        |
+| `collateralAmountUi`      | `string`         | Collateral in reserve token                        |
+| `collateralAmountUiKmb`   | `string`         | Collateral with K/M/B abbreviation                 |
+| `collateralAmountUsdUi`   | `string`         | Collateral in USD                                  |
+| `entryOraclePrice`        | `OraclePriceDto` | Limit trigger price                                |
+| `entryPriceUi`            | `string`         | Entry price (UI format)                            |
+| `leverageUi`              | `string`         | Target leverage                                    |
+| `liquidationPriceUi`      | `string`         | Estimated liquidation price                        |
+| `limitTakeProfitPriceUi`  | `string`         | Attached TP price (`"-"` if none)                  |
+| `limitStopLossPriceUi`    | `string`         | Attached SL price (`"-"` if none)                  |
+| `receiveTokenSymbol`      | `string`         | Token received on close                            |
+| `reserveTokenSymbol`      | `string`         | Token used as reserve (same as `reserveSymbol`)    |
+
+**`TakeProfitOrderUiDto` / `StopLossOrderUiDto` fields:**
+
+| Field                | Type     | Description                                        |
+|----------------------|----------|----------------------------------------------------|
+| `market`             | `string` | Market account pubkey                              |
+| `orderId`            | `number` | Index within the order account                     |
+| `sideUi`             | `string` | `"Long"` or `"Short"`                              |
+| `symbol`             | `string` | Target market symbol                               |
+| `receiveTokenSymbol` | `string` | Token received when triggered                      |
+| `sizeAmountUi`       | `string` | Size in target token                               |
+| `sizeAmountUiKmb`    | `string` | Size with K/M/B abbreviation                       |
+| `sizeUsdUi`          | `string` | Size in USD                                        |
+| `type`               | `string` | `"TP"` for take-profit, `"SL"` for stop-loss       |
+| `triggerPriceUi`     | `string` | Trigger price (UI format)                          |
+| `leverage`           | `string` | Leverage (may be empty string)                     |
+
+### HTTP Error Responses
+
+| Status | Condition                              | Body                                          |
+|--------|----------------------------------------|-----------------------------------------------|
+| `429`  | Per-owner connection limit reached (5) | `"per-owner connection limit reached"`         |
+| `503`  | Global connection limit reached (10k)  | `"global connection limit reached"`            |
+
+---
+
+## 2. Prices — REST Only
+
+Prices are served via REST endpoints, not a streaming connection:
+
+```
+GET /prices              -- All prices, keyed by token symbol
+GET /prices/{symbol}     -- Single token price
+```
+
+**Response shape (`PriceResponse`):**
+
+```json
+{
+  "SOL": {
+    "price": 14852000000,
+    "exponent": -8,
+    "confidence": 0,
+    "priceUi": 148.52,
+    "timestampUs": 1707900000000000,
+    "marketSession": "regular"
+  },
+  "BTC": {
+    "price": 6543200000000,
+    "exponent": -8,
+    "confidence": 0,
+    "priceUi": 65432.00,
+    "timestampUs": 1707900000000000,
+    "marketSession": "regular"
+  }
+}
+```
+
+| Field           | Type     | Description                                                    |
+|-----------------|----------|----------------------------------------------------------------|
+| `price`         | `i64`    | Raw integer price                                              |
+| `exponent`      | `i16`    | Power-of-10 exponent                                           |
+| `confidence`    | `i64`    | Confidence band (always `0` for Pyth Lazer)                    |
+| `priceUi`       | `f64`    | Human-readable price (`price * 10^exponent`)                   |
+| `timestampUs`   | `u64`    | Microsecond Unix timestamp of last price update                |
+| `marketSession` | `string` | `"regular"`, `"preMarket"`, `"postMarket"`, `"overNight"`, or `"closed"` |
+
+The frontend uses Pyth Network WebSocket (via a Web Worker) for real-time price streaming directly from oracle infrastructure, not from the Builder API.
+
+---
+
+## 3. Connection Management
+
+### Connection Limits
+
+| Limit       | Value    | Error on exceed |
+|-------------|----------|-----------------|
+| Per-owner   | **5**    | HTTP 429        |
+| Global      | **10,000** | HTTP 503      |
+
+Limits are checked **before** the WebSocket upgrade. The server uses RAII guards (`ConnectionGuard`) that automatically decrement counters when the connection drops, so slots are reclaimed immediately on disconnect.
+
+### Server Keepalive
+
+- **Ping interval:** Every **30 seconds**, the server sends a WebSocket `Ping` frame.
+- **Pong timeout:** If the client does not respond with a `Pong` within **10 seconds**, the server sends a `Close` frame and terminates the connection.
+- Standard WebSocket clients (browsers, `tokio-tungstenite`, `websockets` for Python) respond to Ping automatically. No client-side code needed for Pong unless you are using a low-level library.
+
+### Cache Lifecycle
+
+The server maintains a per-owner enrichment cache with a refresh loop:
+
+- **First connection for an owner** spawns a background task that recomputes positions and orders.
+- **Subsequent connections** share the same cache (refcounted). The fastest `updateIntervalMs` among active connections wins.
+- **Last connection disconnects** starts a **5-second grace period**. If no reconnection occurs, the cache entry and refresh task are evicted.
+- **Throttle:** The refresh loop never recomputes more than once per **100ms**, even with event-driven triggers.
+
+### Owner Event Channel
+
+Position and order changes from Yellowstone gRPC are broadcast to per-owner channels (`OwnerChannels`). The refresh loop listens for these events:
+
+- `PositionChanged` -- triggers a position recomputation on the next interval tick.
+- `OrderChanged` -- triggers both position and order recomputation (orders are only re-serialized when this event fires).
+
+The broadcast channel has a buffer of **64 events**. If a slow consumer lags, skipped events are logged and orders are force-recomputed.
+
+---
+
+## 4. Reconnection Strategy
+
+The production frontend (`usePositionsAndOrdersSub.ts`) implements a three-tier resilience strategy:
+
+### Tier 1: Exponential Backoff Reconnection
+
+```
+Attempt 1: 1000ms delay
+Attempt 2: 2000ms delay
+Attempt 3: 4000ms delay
+```
+
+- Max reconnect attempts: **3**
+- Base delay: **1000ms**, multiplied by `2^attempt`
+- Connection timeout: **3000ms** -- if the WebSocket does not reach `OPEN` state within 3 seconds, the connection is closed.
+
+### Tier 2: RPC Polling Fallback
+
+After 3 failed reconnect attempts, the client falls back to direct Solana RPC polling (every 5 seconds) to maintain data availability. The WebSocket is considered down but not abandoned.
+
+### Tier 3: Periodic Recovery
+
+While in fallback mode, the client attempts to re-establish the WebSocket connection every **30 seconds**. On success, fallback polling stops and the WebSocket resumes.
+
+---
+
+## 5. Client Examples
+
+### TypeScript (Browser / Node.js)
+
+```typescript
+const owner = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+const wsUrl = `wss://flashapi.trade/owner/${owner}/ws?includePnlInLeverageDisplay=true&updateIntervalMs=1000`;
+
+let ws: WebSocket;
+let reconnectAttempts = 0;
+const MAX_RECONNECTS = 3;
+
+function connect() {
+  ws = new WebSocket(wsUrl);
+
+  // Timeout: close if not open within 3s
+  const timeout = setTimeout(() => {
+    if (ws.readyState !== WebSocket.OPEN) ws.close();
+  }, 3000);
+
+  ws.onopen = () => {
+    clearTimeout(timeout);
+    reconnectAttempts = 0;
+    console.log("Connected to Flash Trade WS");
+  };
+
+  ws.onmessage = (event: MessageEvent) => {
+    const msg = JSON.parse(event.data);
+
+    if (msg.type === "positions") {
+      // msg.data is PositionTableDataUiDto[]
+      console.log(`Received ${msg.data.length} positions`);
+      for (const pos of msg.data) {
+        console.log(
+          `${pos.sideUi} ${pos.marketSymbol}: size=${pos.sizeUsdUi} USD, ` +
+          `PnL=${pos.pnlWithFeeUsdUi} USD, lev=${pos.leverageUi}x, ` +
+          `liq=${pos.liquidationPriceUi}`
+        );
+      }
+    } else if (msg.type === "orders") {
+      // msg.data is OrderDataUiDto[]
+      for (const orderAccount of msg.data) {
+        console.log(`Order account ${orderAccount.key}:`);
+        console.log(`  Limits: ${orderAccount.limitOrders.length}`);
+        console.log(`  TPs: ${orderAccount.takeProfitOrders.length}`);
+        console.log(`  SLs: ${orderAccount.stopLossOrders.length}`);
+      }
+    }
+  };
+
+  ws.onclose = (event) => {
+    clearTimeout(timeout);
+    if (reconnectAttempts < MAX_RECONNECTS) {
+      const delay = 1000 * Math.pow(2, reconnectAttempts);
+      reconnectAttempts++;
+      console.warn(`WS closed (code=${event.code}), reconnecting in ${delay}ms`);
+      setTimeout(connect, delay);
+    } else {
+      console.error("WS max reconnects reached");
+    }
+  };
+
+  ws.onerror = (err) => {
+    console.error("WS error:", err);
+    // onclose fires after onerror, reconnection handled there
+  };
+}
+
+connect();
+```
+
+### Python (websockets library)
+
+```python
+import asyncio
+import json
+import websockets
+
+OWNER = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+WS_URL = (
+    f"wss://flashapi.trade/owner/{OWNER}/ws"
+    f"?includePnlInLeverageDisplay=true&updateIntervalMs=1000"
+)
+
+MAX_RECONNECTS = 3
+BASE_DELAY = 1.0
+
+
+async def listen():
+    attempt = 0
+    while attempt <= MAX_RECONNECTS:
+        try:
+            async with websockets.connect(
+                WS_URL,
+                open_timeout=3,
+                ping_interval=None,  # server handles ping/pong
+            ) as ws:
+                attempt = 0  # reset on successful connect
+                print("Connected to Flash Trade WS")
+
+                async for raw in ws:
+                    msg = json.loads(raw)
+
+                    if msg["type"] == "positions":
+                        for pos in msg["data"]:
+                            print(
+                                f"{pos.get('sideUi')} {pos.get('marketSymbol')}: "
+                                f"size={pos.get('sizeUsdUi')} USD, "
+                                f"PnL={pos.get('pnlWithFeeUsdUi')} USD"
+                            )
+
+                    elif msg["type"] == "orders":
+                        for oa in msg["data"]:
+                            n_limit = len(oa.get("limitOrders", []))
+                            n_tp = len(oa.get("takeProfitOrders", []))
+                            n_sl = len(oa.get("stopLossOrders", []))
+                            print(
+                                f"Orders {oa['key']}: "
+                                f"{n_limit} limit, {n_tp} TP, {n_sl} SL"
+                            )
+
+        except (
+            websockets.ConnectionClosedError,
+            websockets.InvalidURI,
+            OSError,
+        ) as e:
+            delay = BASE_DELAY * (2 ** attempt)
+            attempt += 1
+            print(f"WS error ({e}), reconnecting in {delay}s (attempt {attempt})")
+            await asyncio.sleep(delay)
+
+    print("Max reconnects reached")
+
+
+asyncio.run(listen())
+```
+
+### Browser JavaScript (Minimal)
+
+```javascript
+const owner = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+const ws = new WebSocket(
+  `wss://flashapi.trade/owner/${owner}/ws?includePnlInLeverageDisplay=true&updateIntervalMs=1000`
+);
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "positions") {
+    // Full array of all open positions for this wallet
+    console.table(msg.data.map(p => ({
+      side: p.sideUi,
+      market: p.marketSymbol,
+      size: p.sizeUsdUi,
+      pnl: p.pnlWithFeeUsdUi,
+      leverage: p.leverageUi,
+      liquidation: p.liquidationPriceUi,
+    })));
+  }
+  if (msg.type === "orders") {
+    // Full array of all order accounts for this wallet
+    for (const oa of msg.data) {
+      console.log("Limit orders:", oa.limitOrders);
+      console.log("TP orders:", oa.takeProfitOrders);
+      console.log("SL orders:", oa.stopLossOrders);
+    }
+  }
+};
+```
+
+---
+
+## 6. Best Practices
+
+### Handle Reconnection Gracefully
+
+- Implement exponential backoff (start at 1s, cap at ~4-5s).
+- Set a connection timeout (3s recommended) to detect hung upgrades.
+- Fall back to REST polling (`GET /positions/owner/{owner}`) if WebSocket is persistently unavailable.
+- Periodically attempt WebSocket recovery (every 30s) while in fallback mode.
+- On wallet disconnect, close the WebSocket intentionally and clear local state.
+
+### Understand the Data Model
+
+- **Every message is a full snapshot.** Replace your local state entirely with each incoming `data` array. Do not attempt to merge or diff against previous messages.
+- **Positions update frequently** (every `updateIntervalMs`) because PnL, leverage, and liquidation price change with oracle prices.
+- **Orders update infrequently** -- only on actual on-chain order events. The server internally tracks `orders_generation` and only sends an `"orders"` message when the generation bumps.
+- **Optional fields may be absent.** The server uses `skip_serializing_if` for null optional fields. Always use safe access patterns (`?.` in TypeScript, `.get()` in Python).
+
+### Decode Raw Account Data When Needed
+
+- `positionAccountData` and `orderAccountData` are base64-encoded raw Anchor account data.
+- The enriched fields (all the `*Ui` fields) are sufficient for display purposes.
+- Only decode the raw data if you need access to on-chain BN fields (e.g. exact `sizeAmount` for full-close transactions).
+- Use the Flash Trade Anchor IDL (`perpetuals.json`) with `BorshAccountsCoder` for decoding.
+
+### Rate Limit Considerations
+
+- The minimum `updateIntervalMs` the server accepts is **100ms**. Values below this are clamped.
+- For most UI use cases, **1000ms** (the default) provides a good balance of responsiveness and bandwidth.
+- The server throttles internal recomputation to at most once per **100ms** regardless of `updateIntervalMs`.
+- Each wallet can hold at most **5 concurrent WebSocket connections**. Close stale connections before opening new ones.
+
+### Connection Hygiene
+
+- Close WebSocket connections when they are no longer needed (e.g., wallet disconnect, page navigation).
+- The server has a **5-second grace period** after the last connection drops before evicting the cache. Quick reconnects (e.g., during page transitions) reuse the existing cache without recomputation.
+- Do not rely on Ping/Pong for application-level health checks. The server sends Ping frames automatically. If you need to detect staleness, track the timestamp of the last received message.

--- a/flash-trade/Workflows/BuildTransaction.md
+++ b/flash-trade/Workflows/BuildTransaction.md
@@ -1,0 +1,189 @@
+# BuildTransaction Workflow
+
+How to build, sign, and submit Flash Trade transactions via the REST API.
+
+## Transaction Flow
+
+```
+1. POST /transaction-builder/{action}  →  Preview + unsigned base64 transaction
+2. Decode base64                       →  VersionedTransaction bytes
+3. Sign with wallet keypair            →  Signed transaction
+4. Send to Solana RPC                  →  Transaction signature
+5. Confirm on-chain                    →  Done
+```
+
+**Critical:** Blockhashes expire in ~60 seconds. Sign and submit promptly after step 1.
+
+## Open Position
+
+```bash
+curl -X POST $FLASH_API_URL/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG",
+    "owner": "<WALLET_PUBKEY>",
+    "slippagePercentage": "0.5",
+    "takeProfit": "160.00",
+    "stopLoss": "130.00"
+  }'
+```
+
+**Response includes:** `newEntryPrice`, `newLeverage`, `newLiquidationPrice`, `entryFee`, `marginFeePercentage`, `transactionBase64`, `takeProfitQuote`, `stopLossQuote`
+
+**Options:**
+- Add `"orderType": "LIMIT", "limitPrice": "140.00"` for limit orders
+- Add `"degenMode": true` for >100x leverage
+- Omit `owner` for preview-only (no transaction built)
+- Set `takeProfit` and/or `stopLoss` to include trigger orders in the same transaction
+- Add `"tradingFeeDiscountPercent": 10.0` with `"tokenStakeFafAccount": "<pubkey>"` for fee discounts
+
+## Close Position
+
+```bash
+curl -X POST $FLASH_API_URL/transaction-builder/close-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_PUBKEY>",
+    "inputUsdUi": "500.00",
+    "withdrawTokenSymbol": "USDC",
+    "slippagePercentage": "0.5"
+  }'
+```
+
+**Response includes:** `markPrice`, `entryPrice`, `settledPnl`, `fees`, `receiveTokenAmountUi`, `transactionBase64`
+
+**Partial close:** Set `inputUsdUi` to less than the full position size. Add `"keepLeverageSame": true` to maintain leverage ratio.
+
+## Reverse Position
+
+```bash
+curl -X POST $FLASH_API_URL/transaction-builder/reverse-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_PUBKEY>",
+    "owner": "<WALLET_PUBKEY>",
+    "slippagePercentage": "0.5"
+  }'
+```
+
+Atomically closes the current position and opens an opposite-direction position with the same collateral.
+
+## Add / Remove Collateral
+
+```bash
+# Add collateral (reduce leverage)
+curl -X POST $FLASH_API_URL/transaction-builder/add-collateral \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_PUBKEY>",
+    "depositAmountUi": "50.0",
+    "depositTokenSymbol": "USDC",
+    "owner": "<WALLET_PUBKEY>"
+  }'
+
+# Remove collateral (increase leverage)
+curl -X POST $FLASH_API_URL/transaction-builder/remove-collateral \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_PUBKEY>",
+    "withdrawAmountUsdUi": "25.00",
+    "withdrawTokenSymbol": "USDC",
+    "owner": "<WALLET_PUBKEY>"
+  }'
+```
+
+## Trigger Orders (TP/SL)
+
+```bash
+# Place take-profit
+curl -X POST $FLASH_API_URL/transaction-builder/place-trigger-order \
+  -H "Content-Type: application/json" \
+  -d '{
+    "marketSymbol": "SOL",
+    "side": "LONG",
+    "triggerPriceUi": "160.00",
+    "sizeAmountUi": "0.5",
+    "isStopLoss": false,
+    "owner": "<WALLET_PUBKEY>"
+  }'
+
+# Edit trigger order
+curl -X POST $FLASH_API_URL/transaction-builder/edit-trigger-order \
+  -H "Content-Type: application/json" \
+  -d '{
+    "marketSymbol": "SOL",
+    "side": "LONG",
+    "orderId": 0,
+    "triggerPriceUi": "165.00",
+    "sizeAmountUi": "0.5",
+    "isStopLoss": false,
+    "owner": "<WALLET_PUBKEY>"
+  }'
+
+# Cancel trigger order
+curl -X POST $FLASH_API_URL/transaction-builder/cancel-trigger-order \
+  -H "Content-Type: application/json" \
+  -d '{
+    "marketSymbol": "SOL",
+    "side": "LONG",
+    "orderId": 0,
+    "isStopLoss": false,
+    "owner": "<WALLET_PUBKEY>"
+  }'
+
+# Cancel all trigger orders for a market+side
+curl -X POST $FLASH_API_URL/transaction-builder/cancel-all-trigger-orders \
+  -H "Content-Type: application/json" \
+  -d '{
+    "marketSymbol": "SOL",
+    "side": "LONG",
+    "owner": "<WALLET_PUBKEY>"
+  }'
+```
+
+## Signing & Submitting
+
+See [TransactionFlow.md](../TransactionFlow.md) for complete signing examples in TypeScript, Python, and shell.
+
+**Quick reference (TypeScript):**
+
+```typescript
+import { Connection, VersionedTransaction, Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+
+// 1. Build transaction via API (POST to transaction-builder endpoint)
+const response = await fetch(`${FLASH_API_URL}/transaction-builder/open-position`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(request),
+});
+const { transactionBase64 } = await response.json();
+
+// 2. Decode and sign
+const txBytes = Buffer.from(transactionBase64, "base64");
+const tx = VersionedTransaction.deserialize(txBytes);
+tx.sign([keypair]);
+
+// 3. Submit
+const connection = new Connection(SOLANA_RPC_URL);
+const signature = await connection.sendRawTransaction(tx.serialize(), {
+  skipPreflight: false,
+  maxRetries: 3,
+});
+
+// 4. Confirm
+await connection.confirmTransaction(signature, "confirmed");
+```
+
+## Error Recovery
+
+- **"Blockhash not found"** — Re-call the transaction builder endpoint for a fresh transaction, then sign immediately.
+- **Error 6020 (MaxPriceSlippage)** — Widen slippage tolerance or retry with fresh price.
+- **Error 6034 (MinCollateral)** — Increase collateral amount (use $11-12+ for TP/SL).
+- **Error 6033 (CloseOnlyMode)** — Market only allows close operations.
+
+See [ErrorReference.md](../ErrorReference.md) for all 69 error codes.

--- a/flash-trade/Workflows/ManagePositions.md
+++ b/flash-trade/Workflows/ManagePositions.md
@@ -1,0 +1,200 @@
+# ManagePositions Workflow
+
+Position lifecycle management — monitoring, risk management, and order management.
+
+## Position Lifecycle
+
+```
+1. Open Position     →  Position exists on-chain
+2. Monitor           →  Track PnL, leverage, liquidation risk
+3. Manage Risk       →  Add/remove collateral, set TP/SL
+4. Close/Reverse     →  Exit or flip direction
+```
+
+## Monitor Positions
+
+### REST API (Polling)
+
+```bash
+# Get all positions with enriched PnL data
+curl "$FLASH_API_URL/positions/owner/<WALLET>?includePnlInLeverageDisplay=true"
+```
+
+Key response fields per position:
+- `sideUi` — "Long" or "Short"
+- `marketSymbol` — "SOL", "BTC", etc.
+- `entryPriceUi` — Weighted average entry price
+- `sizeUsdUi` — Position size in USD
+- `collateralUsdUi` — Current collateral in USD
+- `pnlWithFeeUsdUi` — PnL after all fees
+- `pnlPercentageWithFee` — PnL as percentage of collateral
+- `liquidationPriceUi` — Price at which position gets liquidated
+- `leverageUi` — Current effective leverage
+
+### WebSocket (Real-Time)
+
+```javascript
+const ws = new WebSocket(`ws://${FLASH_API_HOST}/owner/${wallet}/ws?updateIntervalMs=1000`);
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "positions") {
+    // msg.data = array of enriched positions
+    for (const pos of msg.data) {
+      console.log(`${pos.marketSymbol} ${pos.sideUi}: PnL ${pos.pnlWithFeeUsdUi} (${pos.pnlPercentageWithFee}%)`);
+    }
+  }
+  if (msg.type === "orders") {
+    // msg.data = array of order accounts with limitOrders, takeProfitOrders, stopLossOrders
+  }
+};
+```
+
+See [WebSocketStreaming.md](../WebSocketStreaming.md) for full details.
+
+## Risk Management
+
+### Check Liquidation Risk
+
+A position is liquidated when the oracle price crosses the `liquidationPriceUi`. Monitor the gap between current price and liquidation price.
+
+```bash
+# Get current price
+curl $FLASH_API_URL/prices/SOL
+
+# Compare with position's liquidationPriceUi
+# If gap is narrowing, consider adding collateral or reducing size
+```
+
+### Add Collateral (Reduce Leverage)
+
+```bash
+curl -X POST $FLASH_API_URL/transaction-builder/add-collateral \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_KEY>",
+    "depositAmountUi": "50.0",
+    "depositTokenSymbol": "USDC",
+    "owner": "<WALLET>"
+  }'
+```
+
+### Preview Margin Adjustment
+
+Before adding/removing collateral, preview the effect:
+
+```bash
+curl -X POST $FLASH_API_URL/preview/margin \
+  -H "Content-Type: application/json" \
+  -d '{
+    "positionKey": "<POSITION_KEY>",
+    "marginDeltaUsdUi": "50.00",
+    "action": "ADD"
+  }'
+# Response: newLeverageUi, newLiquidationPriceUi, maxAmountUsdUi
+```
+
+## Set Take-Profit & Stop-Loss
+
+### At Open Time
+
+Include `takeProfit` and `stopLoss` in the open-position request:
+
+```json
+{
+  "inputTokenSymbol": "USDC",
+  "outputTokenSymbol": "SOL",
+  "inputAmountUi": "100.0",
+  "leverage": 5.0,
+  "tradeType": "LONG",
+  "owner": "<WALLET>",
+  "takeProfit": "160.00",
+  "stopLoss": "130.00"
+}
+```
+
+### On Existing Positions
+
+```bash
+# Place TP
+curl -X POST $FLASH_API_URL/transaction-builder/place-trigger-order \
+  -d '{"marketSymbol":"SOL","side":"LONG","triggerPriceUi":"160","sizeAmountUi":"1.0","isStopLoss":false,"owner":"<WALLET>"}'
+
+# Place SL
+curl -X POST $FLASH_API_URL/transaction-builder/place-trigger-order \
+  -d '{"marketSymbol":"SOL","side":"LONG","triggerPriceUi":"130","sizeAmountUi":"1.0","isStopLoss":true,"owner":"<WALLET>"}'
+```
+
+### Preview TP/SL Before Placing
+
+```bash
+# Forward mode: given trigger price, what's the PnL?
+curl -X POST $FLASH_API_URL/preview/tp-sl \
+  -d '{"mode":"forward","positionKey":"<KEY>","triggerPriceUi":"160"}'
+
+# Reverse PnL mode: given target PnL, what trigger price?
+curl -X POST $FLASH_API_URL/preview/tp-sl \
+  -d '{"mode":"reverse_pnl","positionKey":"<KEY>","targetPnlUsdUi":"50"}'
+
+# Reverse ROI mode: given target ROI%, what trigger price?
+curl -X POST $FLASH_API_URL/preview/tp-sl \
+  -d '{"mode":"reverse_roi","positionKey":"<KEY>","targetRoiPercent":"25"}'
+```
+
+### Manage Existing Orders
+
+```bash
+# View all orders for wallet
+curl $FLASH_API_URL/orders/owner/<WALLET>
+
+# Edit a trigger order (change price or size)
+curl -X POST $FLASH_API_URL/transaction-builder/edit-trigger-order \
+  -d '{"marketSymbol":"SOL","side":"LONG","orderId":0,"triggerPriceUi":"165","sizeAmountUi":"0.5","isStopLoss":false,"owner":"<WALLET>"}'
+
+# Cancel a specific order
+curl -X POST $FLASH_API_URL/transaction-builder/cancel-trigger-order \
+  -d '{"marketSymbol":"SOL","side":"LONG","orderId":0,"isStopLoss":false,"owner":"<WALLET>"}'
+
+# Cancel all orders for a market+side
+curl -X POST $FLASH_API_URL/transaction-builder/cancel-all-trigger-orders \
+  -d '{"marketSymbol":"SOL","side":"LONG","owner":"<WALLET>"}'
+```
+
+**Limits:** Max 5 TP orders + 5 SL orders + 5 limit orders per market per wallet.
+
+## Close Position
+
+```bash
+# Full close
+curl -X POST $FLASH_API_URL/transaction-builder/close-position \
+  -d '{"positionKey":"<KEY>","inputUsdUi":"500","withdrawTokenSymbol":"USDC"}'
+
+# Partial close (close $200 of a $500 position)
+curl -X POST $FLASH_API_URL/transaction-builder/close-position \
+  -d '{"positionKey":"<KEY>","inputUsdUi":"200","withdrawTokenSymbol":"USDC","keepLeverageSame":true}'
+```
+
+## Reverse Position
+
+Atomically close and open opposite direction:
+
+```bash
+curl -X POST $FLASH_API_URL/transaction-builder/reverse-position \
+  -d '{"positionKey":"<KEY>","owner":"<WALLET>"}'
+```
+
+## Bot Strategy Pattern
+
+```
+loop every N seconds:
+  1. GET /prices/{symbol}          → current price
+  2. GET /positions/owner/{wallet} → current positions + PnL
+  3. Evaluate strategy conditions
+  4. If action needed:
+     a. POST /transaction-builder/{action} → get preview + tx
+     b. Check preview (fees, leverage, liquidation price)
+     c. Sign and submit transaction
+     d. Confirm on-chain
+  5. GET /orders/owner/{wallet}    → verify orders are correct
+```
+
+For real-time monitoring, use WebSocket instead of polling. See [WebSocketStreaming.md](../WebSocketStreaming.md).

--- a/flash-trade/Workflows/QueryData.md
+++ b/flash-trade/Workflows/QueryData.md
@@ -1,0 +1,140 @@
+# QueryData Workflow
+
+How to read markets, positions, prices, orders, and pool data from Flash Trade.
+
+## Markets & Pools
+
+```bash
+# All markets (includes symbol, side, pool, max leverage)
+curl $FLASH_API_URL/raw/markets
+
+# All pools
+curl $FLASH_API_URL/raw/pools
+
+# All custodies (token configurations within pools)
+curl $FLASH_API_URL/raw/custodies
+
+# Single account by pubkey
+curl $FLASH_API_URL/raw/markets/{pubkey}
+curl $FLASH_API_URL/raw/pools/{pubkey}
+curl $FLASH_API_URL/raw/custodies/{pubkey}
+```
+
+## Prices
+
+```bash
+# All oracle prices (Pyth Lazer, 200ms updates, mainnet only)
+curl $FLASH_API_URL/prices
+
+# Single price by symbol
+curl $FLASH_API_URL/prices/SOL
+curl $FLASH_API_URL/prices/BTC
+curl $FLASH_API_URL/prices/ETH
+```
+
+**Response fields:** `price` (raw i64), `exponent` (i16), `priceUi` (human-readable), `timestampUs`, `marketSession` (`"regular"`, `"preMarket"`, `"postMarket"`, `"overNight"`, or `"closed"`)
+
+## Positions (Enriched with PnL)
+
+```bash
+# All positions for a wallet (enriched with PnL, leverage, liquidation price)
+curl "$FLASH_API_URL/positions/owner/{walletPubkey}?includePnlInLeverageDisplay=true"
+
+# Raw position by pubkey (no enrichment)
+curl $FLASH_API_URL/raw/positions/{positionPubkey}
+```
+
+**Enriched response includes:** `sideUi`, `marketSymbol`, `entryPriceUi`, `sizeUsdUi`, `collateralUsdUi`, `pnlWithFeeUsdUi`, `pnlPercentageWithFee`, `liquidationPriceUi`, `leverageUi`
+
+## Orders (Enriched)
+
+```bash
+# All orders for a wallet (limit orders, TP, SL — enriched)
+curl $FLASH_API_URL/orders/owner/{walletPubkey}
+
+# Raw order by pubkey
+curl $FLASH_API_URL/raw/orders/{orderPubkey}
+```
+
+**Response includes:** `limitOrders[]`, `takeProfitOrders[]`, `stopLossOrders[]` — each with trigger price, size, symbol, side.
+
+## Pool Data (AUM, Utilization, LP Stats)
+
+```bash
+# All pools aggregated (AUM, utilization, LP price)
+curl $FLASH_API_URL/pool-data
+
+# Single pool by pubkey
+curl $FLASH_API_URL/pool-data/{poolPubkey}
+
+# Check if pool data is initialized
+curl $FLASH_API_URL/pool-data/status/initialized
+```
+
+**Note:** Pool data is cached and refreshed every 15 seconds.
+
+## Tokens
+
+```bash
+# List all supported tokens with decimals, mint keys, Pyth feed IDs
+curl $FLASH_API_URL/tokens
+```
+
+**Response includes:** `symbol`, `mintKey`, `decimals`, `isStable`, `isVirtual`, `lazerId`, `isToken2022`
+
+## Preview (Calculate Without Building Transaction)
+
+```bash
+# Preview fees for a limit order
+curl -X POST $FLASH_API_URL/preview/limit-order-fees \
+  -H "Content-Type: application/json" \
+  -d '{"marketSymbol": "SOL", "inputAmountUi": "100", "outputAmountUi": "0.67", "side": "LONG"}'
+
+# Preview exit fee for closing
+curl -X POST $FLASH_API_URL/preview/exit-fee \
+  -H "Content-Type: application/json" \
+  -d '{"positionKey": "<position-pubkey>", "closeAmountUsdUi": "500"}'
+
+# Preview TP/SL PnL calculation
+curl -X POST $FLASH_API_URL/preview/tp-sl \
+  -H "Content-Type: application/json" \
+  -d '{"mode": "forward", "positionKey": "<position-pubkey>", "triggerPriceUi": "160"}'
+
+# Preview margin adjustment
+curl -X POST $FLASH_API_URL/preview/margin \
+  -H "Content-Type: application/json" \
+  -d '{"positionKey": "<position-pubkey>", "marginDeltaUsdUi": "50", "action": "ADD"}'
+```
+
+## Real-Time Streaming
+
+For live updates, use WebSocket instead of polling:
+
+```bash
+# WebSocket: live positions + orders for a wallet
+wscat -c "ws://$FLASH_API_HOST/owner/{walletPubkey}/ws?updateIntervalMs=1000"
+```
+
+See [WebSocketStreaming.md](../WebSocketStreaming.md) for full details.
+
+## Data Freshness
+
+| Source | Update Frequency | Notes |
+|--------|-----------------|-------|
+| Prices | 200ms (Pyth Lazer) | Mainnet only |
+| Positions/Orders (WS) | Configurable (100ms-10s) | Real-time via WebSocket |
+| Positions/Orders (REST) | On-demand | Read from DashMap cache |
+| Pool Data | 15 seconds | Cached aggregate stats |
+| Account Data (RPC bootstrap) | 30 seconds | Periodic full reload + gRPC streaming |
+
+## OpenAPI / Swagger
+
+Full interactive API documentation with schemas:
+
+```bash
+# Swagger UI
+open $FLASH_API_URL/docs/
+
+# OpenAPI JSON spec
+curl $FLASH_API_URL/api-docs/openapi.json
+```

--- a/flash-trade/Workflows/SetupIntegration.md
+++ b/flash-trade/Workflows/SetupIntegration.md
@@ -1,0 +1,112 @@
+# SetupIntegration Workflow
+
+Guide for setting up a Flash Trade integration from scratch.
+
+## Choose Your Integration Path
+
+### Path 1: REST API (Recommended — Any Language)
+
+**Requirements:** HTTP client, Solana keypair for signing
+
+```bash
+# 1. Verify API connectivity
+curl $FLASH_API_URL/health
+
+# 2. Test data access
+curl $FLASH_API_URL/prices
+curl $FLASH_API_URL/raw/markets
+```
+
+**Environment setup:**
+```bash
+export FLASH_API_URL="https://flashapi.trade"  # Production API
+export SOLANA_RPC_URL="https://api.mainnet-beta.solana.com"
+```
+
+**Dependencies (by language):**
+
+| Language | HTTP Client | Solana Signing | Example |
+|----------|-------------|----------------|---------|
+| TypeScript | `fetch` (built-in) | `@solana/web3.js` | See [TransactionFlow.md](../TransactionFlow.md) |
+| Python | `requests` or `httpx` | `solders` | See [TransactionFlow.md](../TransactionFlow.md) |
+| Rust | `reqwest` | `solana-sdk` | Standard Solana patterns |
+| Go | `net/http` | `gagliardetto/solana-go` | Standard Solana patterns |
+| Any | Any HTTP client | Base64 decode + sign | See [TransactionFlow.md](../TransactionFlow.md) |
+
+**Next steps:** [QueryData.md](QueryData.md) → [BuildTransaction.md](BuildTransaction.md)
+
+---
+
+### Path 2: MCP Server (AI Agent Integration)
+
+```bash
+# Install and configure
+npx flash-trade-mcp
+
+# Or with Bun
+bunx flash-trade-mcp
+```
+
+**Claude Code settings.json:**
+```json
+{
+  "mcpServers": {
+    "flash-trade": {
+      "command": "npx",
+      "args": ["flash-trade-mcp"],
+      "env": {
+        "FLASH_API_URL": "https://flashapi.trade",
+        "WALLET_PUBKEY": "<your-wallet-pubkey>",
+        "KEYPAIR_PATH": "~/.config/solana/id.json",
+        "SOLANA_RPC_URL": "https://api.mainnet-beta.solana.com"
+      }
+    }
+  }
+}
+```
+
+**Next steps:** [McpIntegration.md](../McpIntegration.md)
+
+---
+
+### Path 3: TypeScript SDK (Advanced — Direct On-Chain)
+
+```bash
+# Install
+npm install flash-sdk @coral-xyz/anchor @solana/web3.js
+# or
+yarn add flash-sdk @coral-xyz/anchor @solana/web3.js
+```
+
+```typescript
+import { PerpetualsClient, PoolConfig } from "flash-sdk";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection("https://api.mainnet-beta.solana.com");
+const provider = new AnchorProvider(connection, wallet, { commitment: "processed" });
+const poolConfig = PoolConfig.fromIdsByName("Crypto.1", "mainnet-beta");
+
+const client = new PerpetualsClient(
+  provider,
+  new PublicKey(poolConfig.programId),
+  new PublicKey(poolConfig.perpComposibilityProgramId),
+  new PublicKey(poolConfig.fbNftRewardProgramId),
+  new PublicKey(poolConfig.rewardDistributionProgram.programId),
+  { prioritizationFee: 10_000 },
+);
+
+// CRITICAL: Load ALTs before any transaction
+await client.loadAddressLookupTable(poolConfig);
+```
+
+**Next steps:** [SdkReference.md](../SdkReference.md)
+
+## Verify Setup
+
+Regardless of path, verify your integration works:
+
+1. **Can you read market data?** Get prices and markets.
+2. **Can you read wallet data?** Get positions for a known wallet.
+3. **Can you build a transaction?** Use preview-only mode (omit `owner`) to get fee estimates.
+4. **Can you sign and submit?** Try a small test trade on devnet first (note: Pyth prices are stale on devnet).

--- a/flash-trade/examples/api-quickstart/README.md
+++ b/flash-trade/examples/api-quickstart/README.md
@@ -1,0 +1,125 @@
+# API Quick Start Examples
+
+Getting started with the Flash Trade REST API in multiple languages.
+
+## cURL
+
+```bash
+export FLASH_API_URL="https://flashapi.trade"
+
+# 1. Check health
+curl $FLASH_API_URL/health
+
+# 2. Get all prices
+curl $FLASH_API_URL/prices
+
+# 3. Get SOL price
+curl $FLASH_API_URL/prices/SOL
+
+# 4. Get markets
+curl $FLASH_API_URL/raw/markets
+
+# 5. Get positions for a wallet
+curl "$FLASH_API_URL/positions/owner/YOUR_WALLET_PUBKEY?includePnlInLeverageDisplay=true"
+
+# 6. Preview a trade (no transaction built — omit owner)
+curl -X POST $FLASH_API_URL/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG"
+  }'
+
+# 7. Build a real transaction (include owner)
+curl -X POST $FLASH_API_URL/transaction-builder/open-position \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG",
+    "owner": "YOUR_WALLET_PUBKEY",
+    "slippagePercentage": "0.5"
+  }'
+# Response includes transactionBase64 — decode, sign, and submit to Solana
+```
+
+## TypeScript
+
+```typescript
+const FLASH_API_URL = "https://flashapi.trade";
+
+// Read prices
+const prices = await fetch(`${FLASH_API_URL}/prices`).then(r => r.json());
+console.log("SOL:", prices.SOL.priceUi);
+
+// Read positions
+const wallet = "YOUR_WALLET_PUBKEY";
+const positions = await fetch(
+  `${FLASH_API_URL}/positions/owner/${wallet}?includePnlInLeverageDisplay=true`
+).then(r => r.json());
+
+for (const pos of positions) {
+  console.log(`${pos.marketSymbol} ${pos.sideUi}: $${pos.sizeUsdUi} @ ${pos.entryPriceUi}`);
+  console.log(`  PnL: $${pos.pnlWithFeeUsdUi} (${pos.pnlPercentageWithFee}%)`);
+  console.log(`  Liq: $${pos.liquidationPriceUi} | Leverage: ${pos.leverageUi}x`);
+}
+
+// Preview a trade (no owner = preview only)
+const preview = await fetch(`${FLASH_API_URL}/transaction-builder/open-position`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    inputTokenSymbol: "USDC",
+    outputTokenSymbol: "SOL",
+    inputAmountUi: "100.0",
+    leverage: 5.0,
+    tradeType: "LONG",
+  }),
+}).then(r => r.json());
+
+console.log("Entry price:", preview.newEntryPrice);
+console.log("Entry fee:", preview.entryFee);
+console.log("Liquidation:", preview.newLiquidationPrice);
+console.log("Borrow rate/hr:", preview.marginFeePercentage, "%");
+```
+
+## Python
+
+```python
+import requests
+
+FLASH_API_URL = "https://flashapi.trade"
+
+# Read prices
+prices = requests.get(f"{FLASH_API_URL}/prices").json()
+print(f"SOL: ${prices['SOL']['priceUi']}")
+
+# Read positions
+wallet = "YOUR_WALLET_PUBKEY"
+positions = requests.get(
+    f"{FLASH_API_URL}/positions/owner/{wallet}",
+    params={"includePnlInLeverageDisplay": "true"}
+).json()
+
+for pos in positions:
+    print(f"{pos['marketSymbol']} {pos['sideUi']}: ${pos['sizeUsdUi']} @ {pos['entryPriceUi']}")
+    print(f"  PnL: ${pos['pnlWithFeeUsdUi']} ({pos['pnlPercentageWithFee']}%)")
+    print(f"  Liq: ${pos['liquidationPriceUi']} | Leverage: {pos['leverageUi']}x")
+
+# Preview a trade
+preview = requests.post(f"{FLASH_API_URL}/transaction-builder/open-position", json={
+    "inputTokenSymbol": "USDC",
+    "outputTokenSymbol": "SOL",
+    "inputAmountUi": "100.0",
+    "leverage": 5.0,
+    "tradeType": "LONG",
+}).json()
+
+print(f"Entry: {preview['newEntryPrice']}, Fee: {preview['entryFee']}")
+print(f"Liquidation: {preview['newLiquidationPrice']}")
+```

--- a/flash-trade/examples/websocket-bot/README.md
+++ b/flash-trade/examples/websocket-bot/README.md
@@ -1,0 +1,130 @@
+# WebSocket Position Monitor
+
+Real-time position monitoring using the Flash Trade WebSocket endpoint.
+
+## TypeScript (Node.js)
+
+```typescript
+import WebSocket from "ws";
+
+const FLASH_WS_URL = "wss://flashapi.trade";
+const WALLET = "YOUR_WALLET_PUBKEY";
+
+function connect() {
+  const ws = new WebSocket(
+    `${FLASH_WS_URL}/owner/${WALLET}/ws?includePnlInLeverageDisplay=true&updateIntervalMs=2000`
+  );
+
+  ws.on("open", () => {
+    console.log("Connected to Flash Trade WebSocket");
+  });
+
+  ws.on("message", (data: Buffer) => {
+    const msg = JSON.parse(data.toString());
+
+    if (msg.type === "positions") {
+      console.clear();
+      console.log(`\n--- Positions (${new Date().toISOString()}) ---`);
+      for (const pos of msg.data) {
+        const pnlColor = parseFloat(pos.pnlWithFeeUsdUi) >= 0 ? "\x1b[32m" : "\x1b[31m";
+        console.log(
+          `${pos.marketSymbol} ${pos.sideUi.padEnd(5)} | ` +
+          `Size: $${pos.sizeUsdUi.padStart(10)} | ` +
+          `Entry: $${pos.entryPriceUi.padStart(10)} | ` +
+          `${pnlColor}PnL: $${pos.pnlWithFeeUsdUi.padStart(10)} (${pos.pnlPercentageWithFee}%)\x1b[0m | ` +
+          `Liq: $${pos.liquidationPriceUi}`
+        );
+      }
+    }
+
+    if (msg.type === "orders") {
+      for (const order of msg.data) {
+        if (order.takeProfitOrders.length > 0) {
+          console.log(`\nTP Orders:`);
+          for (const tp of order.takeProfitOrders) {
+            console.log(`  ${tp.symbol} ${tp.sideUi}: trigger @ $${tp.triggerPriceUi} (${tp.sizeAmountUi} tokens)`);
+          }
+        }
+        if (order.stopLossOrders.length > 0) {
+          console.log(`SL Orders:`);
+          for (const sl of order.stopLossOrders) {
+            console.log(`  ${sl.symbol} ${sl.sideUi}: trigger @ $${sl.triggerPriceUi} (${sl.sizeAmountUi} tokens)`);
+          }
+        }
+      }
+    }
+  });
+
+  ws.on("close", () => {
+    console.log("Disconnected. Reconnecting in 5s...");
+    setTimeout(connect, 5000);
+  });
+
+  ws.on("error", (err) => {
+    console.error("WebSocket error:", err.message);
+  });
+
+  // Respond to server pings (keepalive)
+  ws.on("ping", () => ws.pong());
+}
+
+connect();
+```
+
+## Python
+
+```python
+import asyncio
+import json
+import websockets
+
+FLASH_WS_URL = "wss://flashapi.trade"
+WALLET = "YOUR_WALLET_PUBKEY"
+
+async def monitor():
+    url = f"{FLASH_WS_URL}/owner/{WALLET}/ws?includePnlInLeverageDisplay=true&updateIntervalMs=2000"
+
+    while True:
+        try:
+            async with websockets.connect(url) as ws:
+                print("Connected to Flash Trade WebSocket")
+
+                async for message in ws:
+                    msg = json.loads(message)
+
+                    if msg["type"] == "positions":
+                        print(f"\n--- Positions ---")
+                        for pos in msg["data"]:
+                            pnl = float(pos["pnlWithFeeUsdUi"])
+                            marker = "+" if pnl >= 0 else ""
+                            print(
+                                f"  {pos['marketSymbol']} {pos['sideUi']:5s} | "
+                                f"Size: ${pos['sizeUsdUi']:>10s} | "
+                                f"PnL: {marker}${pos['pnlWithFeeUsdUi']:>10s} ({pos['pnlPercentageWithFee']}%) | "
+                                f"Liq: ${pos['liquidationPriceUi']}"
+                            )
+
+                    elif msg["type"] == "orders":
+                        for order in msg["data"]:
+                            for tp in order.get("takeProfitOrders", []):
+                                print(f"  TP: {tp['symbol']} @ ${tp['triggerPriceUi']}")
+                            for sl in order.get("stopLossOrders", []):
+                                print(f"  SL: {sl['symbol']} @ ${sl['triggerPriceUi']}")
+
+        except websockets.ConnectionClosed:
+            print("Disconnected. Reconnecting in 5s...")
+            await asyncio.sleep(5)
+        except Exception as e:
+            print(f"Error: {e}. Reconnecting in 10s...")
+            await asyncio.sleep(10)
+
+asyncio.run(monitor())
+```
+
+## Connection Notes
+
+- **Update interval:** `updateIntervalMs` controls how often position updates arrive (100ms to 10s, default 1000ms)
+- **Per-owner limit:** Max 5 concurrent WebSocket connections per wallet
+- **Keepalive:** Server sends Ping every 30s, expects Pong within 10s
+- **Reconnection:** Always implement automatic reconnection with backoff
+- **Message types:** `"positions"` (sent periodically) and `"orders"` (sent on change)

--- a/flash-trade/templates/api-trading-bot.py
+++ b/flash-trade/templates/api-trading-bot.py
@@ -1,0 +1,190 @@
+"""
+Flash Trade API Trading Bot Template (Python)
+
+A simple trading bot that monitors price and opens positions via the REST API.
+Adapt the strategy logic to your needs.
+
+Requirements:
+  pip install requests solders
+
+Usage:
+  export FLASH_API_URL="https://flashapi.trade"
+  export SOLANA_RPC_URL="https://api.mainnet-beta.solana.com"
+  export KEYPAIR_PATH="~/.config/solana/id.json"
+  python api-trading-bot.py
+"""
+
+import json
+import os
+import time
+import base64
+import requests
+from pathlib import Path
+from solders.keypair import Keypair
+from solders.transaction import VersionedTransaction
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+FLASH_API_URL = os.environ.get("FLASH_API_URL", "https://flashapi.trade")
+SOLANA_RPC_URL = os.environ.get("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+KEYPAIR_PATH = os.path.expanduser(os.environ.get("KEYPAIR_PATH", "~/.config/solana/id.json"))
+
+# Strategy parameters
+SYMBOL = "SOL"
+COLLATERAL_USD = "12.0"  # Use $12+ to allow TP/SL (>$10 after fees)
+LEVERAGE = 5.0
+POLL_INTERVAL_SECONDS = 10
+MAX_POSITIONS = 1
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def load_keypair() -> Keypair:
+    """Load Solana keypair from JSON file."""
+    key_data = json.loads(Path(KEYPAIR_PATH).read_text())
+    return Keypair.from_bytes(bytes(key_data))
+
+
+def get_price(symbol: str) -> float:
+    """Get current oracle price for a symbol."""
+    resp = requests.get(f"{FLASH_API_URL}/prices/{symbol}")
+    resp.raise_for_status()
+    return resp.json()["priceUi"]
+
+
+def get_positions(wallet: str) -> list:
+    """Get enriched positions for a wallet."""
+    resp = requests.get(
+        f"{FLASH_API_URL}/positions/owner/{wallet}",
+        params={"includePnlInLeverageDisplay": "true"},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def build_open_position(wallet: str, side: str) -> dict:
+    """Build an open-position transaction via the API."""
+    resp = requests.post(
+        f"{FLASH_API_URL}/transaction-builder/open-position",
+        json={
+            "inputTokenSymbol": "USDC",
+            "outputTokenSymbol": SYMBOL,
+            "inputAmountUi": COLLATERAL_USD,
+            "leverage": LEVERAGE,
+            "tradeType": side,
+            "owner": wallet,
+            "slippagePercentage": "0.5",
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def sign_and_send(tx_base64: str, keypair: Keypair) -> str:
+    """Decode, sign, and submit a base64 transaction to Solana."""
+    tx_bytes = base64.b64decode(tx_base64)
+    unsigned_tx = VersionedTransaction.from_bytes(tx_bytes)
+
+    # Sign the transaction (construct new VersionedTransaction with signature)
+    signed_tx = VersionedTransaction(unsigned_tx.message, [keypair])
+
+    # Submit to Solana RPC
+    encoded = base64.b64encode(bytes(signed_tx)).decode("utf-8")
+    rpc_response = requests.post(
+        SOLANA_RPC_URL,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "sendTransaction",
+            "params": [encoded, {"encoding": "base64", "skipPreflight": False}],
+        },
+    )
+    result = rpc_response.json()
+
+    if "error" in result:
+        raise Exception(f"RPC error: {result['error']}")
+
+    return result["result"]
+
+
+# ─── Strategy ────────────────────────────────────────────────────────────────
+
+def evaluate_strategy(price: float, positions: list) -> str | None:
+    """
+    Replace this with your actual trading logic.
+    Returns "LONG", "SHORT", or None.
+    """
+    # Example: simple price threshold
+    if len(positions) >= MAX_POSITIONS:
+        return None
+
+    # YOUR STRATEGY HERE
+    # if price < 140:
+    #     return "LONG"
+    # if price > 200:
+    #     return "SHORT"
+
+    return None
+
+
+# ─── Main Loop ───────────────────────────────────────────────────────────────
+
+def main():
+    keypair = load_keypair()
+    wallet = str(keypair.pubkey())
+    print(f"Bot started | Wallet: {wallet} | Symbol: {SYMBOL}")
+    print(f"API: {FLASH_API_URL} | RPC: {SOLANA_RPC_URL}")
+
+    # Verify API connectivity
+    health = requests.get(f"{FLASH_API_URL}/health").json()
+    print(f"API health: {health.get('status', 'unknown')}")
+
+    while True:
+        try:
+            # 1. Get current price
+            price = get_price(SYMBOL)
+            print(f"\n[{time.strftime('%H:%M:%S')}] {SYMBOL}: ${price:.2f}")
+
+            # 2. Get current positions
+            positions = get_positions(wallet)
+            for pos in positions:
+                if pos["marketSymbol"] == SYMBOL:
+                    print(
+                        f"  Position: {pos['sideUi']} {pos['sizeUsdUi']} USD | "
+                        f"PnL: ${pos['pnlWithFeeUsdUi']} ({pos['pnlPercentageWithFee']}%) | "
+                        f"Liq: ${pos['liquidationPriceUi']}"
+                    )
+
+            # 3. Evaluate strategy
+            action = evaluate_strategy(price, positions)
+
+            if action:
+                print(f"  >>> Opening {action} position: ${COLLATERAL_USD} @ {LEVERAGE}x")
+
+                # 4. Build transaction
+                result = build_open_position(wallet, action)
+
+                if result.get("err"):
+                    print(f"  ERROR: {result['err']}")
+                elif result.get("transactionBase64"):
+                    print(f"  Entry: ${result['newEntryPrice']} | Fee: ${result['entryFee']}")
+                    print(f"  Liq: ${result['newLiquidationPrice']} | Leverage: {result['newLeverage']}x")
+
+                    # 5. Sign and submit
+                    signature = sign_and_send(result["transactionBase64"], keypair)
+                    print(f"  TX: https://solscan.io/tx/{signature}")
+                else:
+                    print("  No transaction returned")
+
+        except KeyboardInterrupt:
+            print("\nBot stopped.")
+            break
+        except Exception as e:
+            print(f"  Error: {e}")
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()
+```


### PR DESCRIPTION
## Summary

Adds a comprehensive developer integration skill for [Flash Trade](https://beast.flash.trade/), a perpetual futures DEX on Solana.

**What's included:**

- **SKILL.md** — Skill manifest with intent router, quick-start examples, and documentation map
- **ApiReference.md** — Complete REST API reference (28 endpoints, transaction builders, previews)
- **SdkReference.md** — TypeScript SDK guide (`PerpetualsClient`, positions, orders, composability)
- **TransactionFlow.md** — Build-sign-submit lifecycle with TypeScript, Python, and cURL examples
- **WebSocketStreaming.md** — Real-time position/order streaming via WebSocket
- **McpIntegration.md** — MCP server integration (`flash-trade-mcp` on NPM) for AI agents
- **ProtocolConcepts.md** — Domain knowledge (pools, custodies, markets, fees, oracles)
- **ErrorReference.md** — 69 error codes with causes and recovery patterns
- **Workflows/** — Step-by-step guides for setup, querying data, building transactions, and managing positions
- **examples/** — Quick-start examples (cURL, TypeScript, Python) and WebSocket bot patterns
- **templates/** — Production-ready Python trading bot template

**Integration paths covered:** REST API (any language), TypeScript SDK (direct on-chain), MCP Server (AI agents), WebSocket (real-time monitoring)

**Program IDs:**
- Mainnet: `FLASH6Lo6h3iasJKWDs2F8TkW2UKf3s15C8PMGuVfgBn`
- Devnet: `FTPP4jEWW1n8s2FEccwVfS9KCPjpndaswg7Nkkuz4ER4`

## Placement Note

We placed this as a top-level `flash-trade/` directory alongside the existing `skill/` directory. Happy to restructure if you'd prefer a different location (e.g., under `skill/references/flash-trade/`).

## Test plan

- [ ] All markdown files render correctly on GitHub
- [ ] Code examples in TypeScript, Python, and cURL are syntactically valid
- [ ] SKILL.md intent router links resolve to correct reference files
- [ ] No modifications to existing `skill/` directory or other files

🤖 Generated with [Claude Code](https://claude.ai/code)