### PR TITLE
fix: update outdated solana security best practices link

### DIFF
--- a/skill/references/resources.md
+++ b/skill/references/resources.md
@@ -74,7 +74,7 @@ description: Authoritative Solana learning platforms, documentation, tooling ref
 
 ## Security
 - [Blueshift Program Security Course](https://learn.blueshift.gg/en/courses/program-security)
-- [Solana Security Best Practices](https://solana.com/docs/programs/security)
+- [Solana Security Best Practices](https://solana.com/docs/core/security)
 
 ## Performance and Optimization
 - [Solana Optimized Programs](https://github.com/Laugharne/solana_optimized_programs)


### PR DESCRIPTION
## Fix: Broken Solana security best practices link

### Changes
- Updated outdated Solana security documentation link
- Replaced deprecated `/docs/programs/security` with `/docs/core/security`

### Notes
- Verified link is working and points to latest official docs

Fixes #18