### PR TITLE
chore: migrate kit references to createClient + .use() plugin pattern

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -31,8 +31,16 @@ Use this Skill when the user asks for:
 
 2) **SDK: @solana/kit first**
 - Build clients with `createClient()` from `@solana/kit`, then `.use(...)` plugins:
-  `createClient().use(signer(mySigner)).use(solanaRpc({ rpcUrl }))` (or `solanaLocalRpc` / `solanaDevnetRpc` / `solanaMainnetRpc` from `@solana/kit-plugin-rpc`).
-- Default to `signer()` / `signerFromFile()` / `generatedSignerWithSol()` from `@solana/kit-plugin-signer` — they set both `payer` and `identity` to the same keypair (the common case). Reach for the role-specific variants (`payer()` + `identity()`) only when fees and authority must come from different keypairs.
+  ```ts
+  createClient()
+    .use(signer(mySigner))
+    .use(solanaRpc({ rpcUrl }));
+  // or solanaLocalRpc / solanaDevnetRpc / solanaMainnetRpc from @solana/kit-plugin-rpc
+  ```
+- Default to `signer()` / `signerFromFile()` / `generatedSignerWithSol()` from
+  `@solana/kit-plugin-signer` — they set both `payer` and `identity` to the same keypair (the
+  common case). Reach for the role-specific variants (`payer()` + `identity()`) only when fees
+  and authority must come from different keypairs.
 - Use `@solana-program/*` program plugins (e.g., `tokenProgram()`) for fluent instruction APIs.
 - Prefer Kit types (`Address`, `Signer`, transaction message APIs, codecs).
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -37,10 +37,11 @@ Use this Skill when the user asks for:
     .use(solanaRpc({ rpcUrl }));
   // or solanaLocalRpc / solanaDevnetRpc / solanaMainnetRpc from @solana/kit-plugin-rpc
   ```
-- Default to `signer()` / `signerFromFile()` / `generatedSignerWithSol()` from
+- Default to `signer()` / `signerFromFile()` / `generatedSigner()` from
   `@solana/kit-plugin-signer` — they set both `payer` and `identity` to the same keypair (the
-  common case). Reach for the role-specific variants (`payer()` + `identity()`) only when fees
-  and authority must come from different keypairs.
+  common case). For fresh local/devnet signers, install the RPC/LiteSVM plugin after
+  `generatedSigner()`, then fund with `airdropSigner(...)`. Reach for the role-specific variants
+  (`payer()` + `identity()`) only when fees and authority must come from different keypairs.
 - Use `@solana-program/*` program plugins (e.g., `tokenProgram()`) for fluent instruction APIs.
 - Prefer Kit types (`Address`, `Signer`, transaction message APIs, codecs).
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -30,7 +30,9 @@ Use this Skill when the user asks for:
 - Prefer Wallet Standard discovery/connect via the framework-kit client.
 
 2) **SDK: @solana/kit first**
-- Start with `createClient` / `createLocalClient` from `@solana/kit-client-rpc` for RPC + transaction sending.
+- Build clients with `createClient()` from `@solana/kit`, then `.use(...)` plugins:
+  `createClient().use(signer(mySigner)).use(solanaRpc({ rpcUrl }))` (or `solanaLocalRpc` / `solanaDevnetRpc` / `solanaMainnetRpc` from `@solana/kit-plugin-rpc`).
+- Default to `signer()` / `signerFromFile()` / `generatedSignerWithSol()` from `@solana/kit-plugin-signer` — they set both `payer` and `identity` to the same keypair (the common case). Reach for the role-specific variants (`payer()` + `identity()`) only when fees and authority must come from different keypairs.
 - Use `@solana-program/*` program plugins (e.g., `tokenProgram()`) for fluent instruction APIs.
 - Prefer Kit types (`Address`, `Signer`, transaction message APIs, codecs).
 

--- a/skill/references/kit/advanced.md
+++ b/skill/references/kit/advanced.md
@@ -390,6 +390,8 @@ export type ClientPlugin<TInput extends object, TOutput extends Promise<object> 
 ### Basic Plugin
 
 ```ts
+import { createClient } from '@solana/kit';
+
 function apple() {
   return <T extends object>(client: T) => ({
     ...client,
@@ -397,7 +399,7 @@ function apple() {
   });
 }
 
-const client = createEmptyClient().use(apple());
+const client = createClient().use(apple());
 client.fruit; // 'apple'
 ```
 
@@ -413,8 +415,8 @@ function appleTart() {
   });
 }
 
-createEmptyClient().use(apple()).use(appleTart()); // ✅ Ok
-createEmptyClient().use(appleTart());              // ❌ TypeScript error
+createClient().use(apple()).use(appleTart()); // ✅ Ok
+createClient().use(appleTart());              // ❌ TypeScript error
 ```
 
 ### Async Plugin
@@ -428,7 +430,7 @@ function magicFruit() {
 }
 
 // use() handles awaiting automatically
-const client = await createEmptyClient().use(magicFruit()).use(apple());
+const client = await createClient().use(magicFruit()).use(apple());
 ```
 
 ---
@@ -442,13 +444,13 @@ The plugin system enables building purpose-built clients for specific domains. H
 [Kora](https://github.com/solana-foundation/kora) builds a gasless payment client by composing standard plugins with a custom Kora plugin:
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { planAndSendTransactions, transactionPlanExecutor, transactionPlanner } from '@solana/kit-plugin-instruction-plan';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 import { rpc } from '@solana/kit-plugin-rpc';
 
 export async function createKitKoraClient(config) {
-  return createEmptyClient()
+  return createClient()
     .use(rpc(config.rpcUrl))
     .use(koraPlugin({ apiKey: config.apiKey, endpoint: config.endpoint }))
     .use(payer(payerSigner))
@@ -469,21 +471,21 @@ Key pattern: Standard plugins (`rpc`, `payer`, `planAndSendTransactions`) combin
 [Solana Pay](https://github.com/amilz/solana-pay) builds role-specific clients — a read-only merchant client and a full wallet client:
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 import { rpc, rpcTransactionPlanExecutor, rpcTransactionPlanner } from '@solana/kit-plugin-rpc';
 
 // Merchant: read-only, no payer needed
 function createMerchantClient(config) {
-  return createEmptyClient()
+  return createClient()
     .use(rpc(config.rpcUrl))
     .use(solanaPayMerchant()); // Adds client.pay.encodeURL, findReference, validateTransfer
 }
 
 // Wallet: full tx capabilities
 function createWalletClient(config) {
-  return createEmptyClient()
+  return createClient()
     .use(rpc(config.rpcUrl))
     .use(payer(config.payer))
     .use(rpcTransactionPlanner())
@@ -507,8 +509,8 @@ Key pattern: Same base plugins, different compositions for different roles. Doma
 
 When building a domain-specific client:
 
-1. Start with `createEmptyClient()` from `@solana/kit`
-2. Add standard plugins for capabilities you need (`rpc`, `payer`, `planAndSendTransactions`)
+1. Start with `createClient()` from `@solana/kit`
+2. Add standard plugins for capabilities you need (`rpc`, `payer` from `@solana/kit-plugin-signer`, `planAndSendTransactions`)
 3. Swap `transactionPlanner` / `transactionPlanExecutor` if you need custom tx lifecycle (like Kora)
 4. Add your domain plugin(s) that extend the client with domain-specific methods
 5. Export a factory function (`createMyClient(config)`) for consumers

--- a/skill/references/kit/gotchas.md
+++ b/skill/references/kit/gotchas.md
@@ -11,33 +11,35 @@ Common type errors and runtime pitfalls with their fixes.
 
 ### Plugin Ordering — Type Error
 
-**Cause:** Plugins installed before their dependencies.
+**Cause:** Plugins installed before their dependencies. `solanaRpc` / `solanaLocalRpc` / `solanaDevnetRpc` / `litesvm` all require a `payer` to be installed first; low-level `rpcTransactionPlanner` / `rpcTransactionPlanExecutor` require `rpc` and `payer`.
 
 ```ts
-// ❌ Type error — planner requires rpc
-createEmptyClient()
-  .use(rpcTransactionPlanner())
-  .use(rpc(url));
+// ❌ Type error — solanaRpc requires payer
+createClient()
+  .use(solanaRpc({ rpcUrl: url }))
+  .use(signer(mySigner));
 
-// ✅ Fix: Install dependencies first
-createEmptyClient()
-  .use(rpc(url))
-  .use(payer(signer))
-  .use(rpcTransactionPlanner())
-  .use(planAndSendTransactions());
+// ✅ Fix: signer first (sets payer + identity), then RPC bundle
+createClient()
+  .use(signer(mySigner))
+  .use(solanaRpc({ rpcUrl: url }));
 ```
 
 ### Forgetting to `await` Async Client
 
-**Cause:** Some plugins (e.g., `payerFromFile`, `generatedPayer`, `createLocalClient`) are async.
+**Cause:** Some plugins (e.g., `signerFromFile`, `generatedSigner`, `generatedSignerWithSol`) are async, and `.use()` automatically threads the promise through the chain.
 
 ```ts
 // ❌ Runtime error — client is a Promise, not a client
-const client = createLocalClient();
+const client = createClient()
+  .use(signerFromFile('./id.json'))
+  .use(solanaLocalRpc());
 client.sendTransaction([ix]); // TypeError: not a function
 
 // ✅ Fix: await the client
-const client = await createLocalClient();
+const client = await createClient()
+  .use(signerFromFile('./id.json'))
+  .use(solanaLocalRpc());
 await client.sendTransaction([ix]);
 ```
 
@@ -192,8 +194,8 @@ if (!account.exists) {
 
 | Gotcha | Fix |
 |--------|-----|
-| Plugin ordering type error | Install dependencies before dependents |
-| Forgot to `await` async client | `const client = await createLocalClient()` |
+| Plugin ordering type error | Install dependencies before dependents (`signer()` before `solanaRpc`/`litesvm`) |
+| Forgot to `await` async client | `const client = await createClient().use(signerFromFile(...)).use(solanaLocalRpc())` |
 | `IInstruction` doesn't exist | Use `Instruction` from `@solana/kit` |
 | "Transaction message must be signed" | `assertTransactionMessageIsFullySigned(msg)` |
 | "Missing blockhash lifetime" | `assertTransactionMessageHasBlockhashLifetime(msg)` |

--- a/skill/references/kit/overview.md
+++ b/skill/references/kit/overview.md
@@ -88,19 +88,7 @@ After applying `solanaRpc` / `solanaLocalRpc` / `solanaDevnetRpc` / `solanaMainn
 | `client.airdrop(address, lamports)` | Faucet (devnet/local/litesvm only) |
 | `client.svm` | LiteSVM instance (litesvm plugin only) |
 
-**`solanaRpc` config options** (passed to `solanaRpc({ ... })`):
-
-| Option | Description |
-|--------|-------------|
-| `rpcUrl` | Solana RPC endpoint (required) |
-| `rpcSubscriptionsUrl` | WS endpoint (defaults to `rpcUrl` with `http`→`ws`) |
-| `rpcConfig` | Forwarded to `createSolanaRpc` |
-| `rpcSubscriptionsConfig` | Forwarded to `createSolanaRpcSubscriptions` |
-| `transactionConfig` | Tx planner options (e.g., priority fees) |
-| `maxConcurrency` | Concurrent transaction limit (default: 10) |
-| `skipPreflight` | Always skip preflight simulation (default: false) |
-
-See [plugins.md](plugins.md) for the full plugin catalog and custom composition.
+`solanaRpc({ ... })` accepts `rpcUrl` (required) plus `rpcSubscriptionsUrl`, `transactionConfig` (priority fees), `maxConcurrency`, `skipPreflight`, and the underlying `rpcConfig` / `rpcSubscriptionsConfig`. See [plugins.md](plugins.md) for the full options table, plugin catalog, and custom composition.
 
 ## Core Concepts
 

--- a/skill/references/kit/overview.md
+++ b/skill/references/kit/overview.md
@@ -30,7 +30,7 @@ import { signerFromFile } from '@solana/kit-plugin-signer';
 // `signerFromFile` sets BOTH payer and identity to the loaded keypair (the common case).
 // Other options:
 //   - `signer(existingSigner)`              // explicit signer you already hold
-//   - `generatedSignerWithSol(lamports(n))` // generate + airdrop a fresh keypair (must come AFTER solanaLocalRpc, or use rpcAirdrop first)
+//   - `generatedSigner()` + `airdropSigner(lamports(n))` // fresh local/devnet signer, funded after RPC is installed
 //   - `payer(...)` + `identity(...)`        // when fees and authority come from different keypairs
 const client = await createClient()
   .use(signerFromFile('~/.config/solana/id.json'))
@@ -59,11 +59,14 @@ await client.sendTransaction([myInstruction]);
 ### Testing with LiteSVM
 
 ```ts
-import { createClient } from '@solana/kit';
+import { createClient, lamports } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
-import { signer } from '@solana/kit-plugin-signer';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 
-const client = createClient().use(signer(mySigner)).use(litesvm());
+const client = await createClient()
+  .use(generatedSigner())
+  .use(litesvm())
+  .use(airdropSigner(lamports(1_000_000_000n)));
 
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 await client.sendTransaction([myInstruction]);
@@ -263,7 +266,7 @@ See [codama.md](codama.md) for naming conventions and patterns.
 |---------|---------|
 | `@solana/kit` | Main SDK, re-exports all sub-packages, exports `createClient` |
 | `@solana/kit-plugin-rpc` | All-in-one RPC plugins: `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc` (plus low-level `rpc`, `rpcAirdrop`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`) |
-| `@solana/kit-plugin-signer` | Signer plugins. Default `signer*` variants set both `payer` and `identity` (`signer`, `generatedSigner`, `generatedSignerWithSol`, `signerFromFile`, `airdropSigner`). Role-specific `payer*` and `identity*` variants for when the two roles differ. |
+| `@solana/kit-plugin-signer` | Signer plugins. Default `signer*` variants set both `payer` and `identity` (`signer`, `generatedSigner`, `signerFromFile`). Use `airdropSigner` to fund an already-installed signer; use `generatedSignerWithSol` only when an airdrop function is already installed. Role-specific `payer*` and `identity*` variants for when the two roles differ. |
 | `@solana/kit-plugin-litesvm` | All-in-one `litesvm` plugin (Node.js only) for in-memory testing |
 | `@solana/kit-plugin-airdrop` | Standalone airdrop plugin (most users get this via `solanaDevnetRpc`/`solanaLocalRpc`) |
 | `@solana/kit-plugin-instruction-plan` | `planAndSendTransactions` and instruction batching primitives |

--- a/skill/references/kit/overview.md
+++ b/skill/references/kit/overview.md
@@ -1,31 +1,41 @@
 ---
 title: "@solana/kit Quick Start"
-description: Quick-start guide for @solana/kit using plugin clients for simple setup, transaction sending, account fetching, and common Solana patterns.
+description: Quick-start guide for @solana/kit using createClient + .use() plugin composition for RPC, signers, transaction sending, account fetching, and common Solana patterns.
 ---
 
 # @solana/kit Reference
 
-`@solana/kit` is the JavaScript SDK for building Solana applications. Modular, tree-shakable, full TypeScript support.
+`@solana/kit` is the JavaScript SDK for building Solana applications. Modular, tree-shakable, full TypeScript support. Clients are built by composing plugins onto `createClient()` via `.use()`.
 
 ## Installation
 
 ```bash
-npm install @solana/kit @solana/kit-client-rpc
-# or: pnpm add @solana/kit @solana/kit-client-rpc
+npm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer
+# or: pnpm add @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer
 ```
 
-Minimum version: `@solana/kit@^6.0.0` (recommended to fetch the latest version before installing)
+For LiteSVM testing add `@solana/kit-plugin-litesvm`. For Codama-generated program clients add the relevant `@solana-program/*` package(s).
+
+Minimum version: Solana Kit v6.8.0.
 
 ## Quick Start
 
 ### Local Development
 
 ```ts
-import { createLocalClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
 
-const client = await createLocalClient();
+// `signerFromFile` sets BOTH payer and identity to the loaded keypair (the common case).
+// Other options:
+//   - `signer(existingSigner)`              // explicit signer you already hold
+//   - `generatedSignerWithSol(lamports(n))` // generate + airdrop a fresh keypair (must come AFTER solanaLocalRpc, or use rpcAirdrop first)
+//   - `payer(...)` + `identity(...)`        // when fees and authority come from different keypairs
+const client = await createClient()
+  .use(signerFromFile('~/.config/solana/id.json'))
+  .use(solanaLocalRpc());
 
-// Payer is auto-generated and funded
 console.log('Payer:', client.payer.address);
 await client.sendTransaction([myInstruction]);
 ```
@@ -33,53 +43,64 @@ await client.sendTransaction([myInstruction]);
 ### Production (Mainnet/Devnet)
 
 ```ts
-import { generateKeyPairSigner } from '@solana/kit';
-import { createClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc, solanaMainnetRpc } from '@solana/kit-plugin-rpc';
+import { signer } from '@solana/kit-plugin-signer';
 
-const payer = await generateKeyPairSigner();
-const client = createClient({
-  url: 'https://api.devnet.solana.com',
-  payer,
-});
+const client = createClient()
+  .use(signer(mySigner)) // sets payer + identity; use payer(...) + identity(...) if they differ
+  .use(solanaDevnetRpc()); // or solanaMainnetRpc({ rpcUrl: 'https://...' })
 
 await client.sendTransaction([myInstruction]);
 ```
+
+`solanaDevnetRpc()` defaults to `https://api.devnet.solana.com` and bundles airdrop. `solanaMainnetRpc({ rpcUrl })` is type-narrowed to a mainnet URL — no devnet-only methods like `airdrop`.
 
 ### Testing with LiteSVM
 
 ```ts
-import { createClient } from '@solana/kit-client-litesvm';
+import { createClient } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { signer } from '@solana/kit-plugin-signer';
 
-const client = await createClient();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 await client.sendTransaction([myInstruction]);
 ```
 
+Full documentation: [LiteSVM](https://www.litesvm.com/docs/typescript/getting-started).
+
 ## Client API
 
-All clients from `@solana/kit-client-rpc` expose:
+After applying `solanaRpc` / `solanaLocalRpc` / `solanaDevnetRpc` / `solanaMainnetRpc` (or `litesvm`), the client exposes:
 
 | Property/Method | Description |
 |-----------------|-------------|
 | `client.rpc` | RPC methods (`getBalance`, `getAccountInfo`, etc.) |
-| `client.rpcSubscriptions` | WebSocket subscriptions |
-| `client.payer` | Transaction fee payer signer |
+| `client.rpcSubscriptions` | WebSocket subscriptions (RPC plugins only) |
+| `client.payer` | Transaction fee payer signer (set by `signer()` or `payer()`) |
+| `client.identity` | Authority signer (set by `signer()` or `identity()`) |
 | `client.sendTransaction(instructions)` | Plan + sign + send in one call |
-| `client.planTransaction(instructions)` | Plan without executing |
+| `client.sendTransactions(plan)` | Execute a planned multi-tx plan |
+| `client.planTransaction(s)` | Plan without executing |
+| `client.getMinimumBalance(dataSize)` | Rent-exempt minimum lamports |
+| `client.airdrop(address, lamports)` | Faucet (devnet/local/litesvm only) |
+| `client.svm` | LiteSVM instance (litesvm plugin only) |
 
-`createLocalClient` also provides `client.airdrop(address, amount)`.
-
-**Config options for `createClient`:**
+**`solanaRpc` config options** (passed to `solanaRpc({ ... })`):
 
 | Option | Description |
 |--------|-------------|
-| `url` | Solana RPC endpoint (required) |
-| `payer` | `TransactionSigner` fee payer (required) |
-| `priorityFees` | `MicroLamports` per compute unit |
+| `rpcUrl` | Solana RPC endpoint (required) |
+| `rpcSubscriptionsUrl` | WS endpoint (defaults to `rpcUrl` with `http`→`ws`) |
+| `rpcConfig` | Forwarded to `createSolanaRpc` |
+| `rpcSubscriptionsConfig` | Forwarded to `createSolanaRpcSubscriptions` |
+| `transactionConfig` | Tx planner options (e.g., priority fees) |
 | `maxConcurrency` | Concurrent transaction limit (default: 10) |
-| `skipPreflight` | Bypass simulation checks (default: false) |
+| `skipPreflight` | Always skip preflight simulation (default: false) |
 
-See [plugins.md](plugins.md) for custom client composition and available plugins.
+See [plugins.md](plugins.md) for the full plugin catalog and custom composition.
 
 ## Core Concepts
 
@@ -116,11 +137,14 @@ See [codecs.md](codecs.md) for full codec patterns.
 ### Send SOL Transfer
 
 ```ts
-import { address, lamports } from '@solana/kit';
+import { createClient, address, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
 import { getTransferSolInstruction } from '@solana-program/system';
-import { createLocalClient } from '@solana/kit-client-rpc';
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(signerFromFile('~/.config/solana/id.json'))
+  .use(solanaLocalRpc());
 
 const ix = getTransferSolInstruction({
   source: client.payer,
@@ -148,11 +172,16 @@ See [accounts.md](accounts.md) for batch fetching, PDAs, subscriptions, and toke
 Use the `tokenProgram()` plugin from `@solana-program/token` for a fluent token API. It auto-derives ATAs, auto-creates them if needed, and defaults the payer from the client.
 
 ```ts
-import { generateKeyPairSigner } from '@solana/kit';
-import { createLocalClient } from '@solana/kit-client-rpc';
+import { createClient, generateKeyPairSigner } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
 import { tokenProgram } from '@solana-program/token';
 
-const client = await createLocalClient().use(tokenProgram());
+const client = await createClient()
+  .use(signerFromFile('~/.config/solana/id.json'))
+  .use(solanaLocalRpc())
+  .use(tokenProgram());
+
 const mintAuthority = await generateKeyPairSigner();
 const mint = await generateKeyPairSigner();
 
@@ -188,13 +217,18 @@ See [programs/token.md](programs/token.md) for low-level instruction patterns an
 
 ### Custom Program Operations
 
-Programs that generate a plugin with Solana Kit follow the same pattern:
+Programs that ship a Kit plugin follow the same `.use()` pattern:
 
 ```ts
-import { createClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { signer } from '@solana/kit-plugin-signer';
 import { myProgram } from '@my-programs/operations';
 
-const client = await createClient().use(tokenProgram());
+const client = createClient()
+  .use(signer(mySigner))
+  .use(solanaDevnetRpc())
+  .use(myProgram());
 
 await client.myProgram.instructions
   .handyInstruction({ /* args */ })
@@ -239,19 +273,17 @@ See [codama.md](codama.md) for naming conventions and patterns.
 
 | Package | Purpose |
 |---------|---------|
-| `@solana/kit` | Main SDK, re-exports all sub-packages |
-| `@solana/kit-client-rpc` | Pre-configured RPC clients (`createClient`, `createLocalClient`) |
-| `@solana/kit-client-litesvm` | Pre-configured LiteSVM client for testing |
-| `@solana/kit-plugin-rpc` | RPC plugin for custom clients |
-| `@solana/kit-plugin-payer` | Payer management plugin |
-| `@solana/kit-plugin-airdrop` | Airdrop capability plugin |
-| `@solana/kit-plugin-instruction-plan` | Transaction planning + execution plugin |
-| `@solana/kit-plugin-litesvm` | LiteSVM plugin |
+| `@solana/kit` | Main SDK, re-exports all sub-packages, exports `createClient` |
+| `@solana/kit-plugin-rpc` | All-in-one RPC plugins: `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc` (plus low-level `rpc`, `rpcAirdrop`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`) |
+| `@solana/kit-plugin-signer` | Signer plugins. Default `signer*` variants set both `payer` and `identity` (`signer`, `generatedSigner`, `generatedSignerWithSol`, `signerFromFile`, `airdropSigner`). Role-specific `payer*` and `identity*` variants for when the two roles differ. |
+| `@solana/kit-plugin-litesvm` | All-in-one `litesvm` plugin (Node.js only) for in-memory testing |
+| `@solana/kit-plugin-airdrop` | Standalone airdrop plugin (most users get this via `solanaDevnetRpc`/`solanaLocalRpc`) |
+| `@solana/kit-plugin-instruction-plan` | `planAndSendTransactions` and instruction batching primitives |
 | `@solana/addresses` | Address validation |
 | `@solana/accounts` | Account fetching/decoding |
 | `@solana/codecs` | Data encoding/decoding |
-| `@solana/rpc` | JSON RPC client |
-| `@solana/rpc-subscriptions` | WebSocket subscriptions |
+| `@solana/rpc` | JSON RPC client primitives |
+| `@solana/rpc-subscriptions` | WebSocket subscription primitives |
 | `@solana/transactions` | Compile/sign/serialize |
 | `@solana/transaction-messages` | Build tx messages |
 | `@solana/signers` | Signing abstraction |
@@ -263,15 +295,15 @@ See [codama.md](codama.md) for naming conventions and patterns.
 
 ## Best Practices
 
-1. **Use plugin clients** — `createClient` / `createLocalClient` for most use cases
-2. **Use branded types** — `address()`, `lamports()`, `signature()`
-3. **Use `@solana-program/*`** instruction builders over hand-rolled instruction data
-4. **Handle account existence** — `assertAccountExists()` before decode
-5. **Set compute budget** — use `priorityFees` config option or manual CU estimation for production
+1. **Compose with `.use()`** — `createClient().use(signer(...)).use(solanaRpc(...))`; the signer plugin must come before the RPC/litesvm plugin. Use the role-specific `payer()` + `identity()` variants only when fees and authority come from different keypairs.
+2. **Use branded types** — `address()`, `lamports()`, `signature()`.
+3. **Use `@solana-program/*`** instruction builders over hand-rolled instruction data.
+4. **Handle account existence** — `assertAccountExists()` before decode.
+5. **Set compute budget** — pass `transactionConfig` to `solanaRpc({ ... })` or use manual CU estimation for production. See [programs/compute-budget.md](programs/compute-budget.md).
 
 ## Reference Files
 
-- [plugins.md](plugins.md) — Plugin clients, custom composition, available plugins
+- [plugins.md](plugins.md) — Plugin catalog, custom composition, ordering rules
 - [accounts.md](accounts.md) — Fetching, decoding, batch, PDAs, subscriptions
 - [codecs.md](codecs.md) — Complete codec patterns
 - [react.md](react.md) — React hooks and wallet integration

--- a/skill/references/kit/plugins.md
+++ b/skill/references/kit/plugins.md
@@ -85,26 +85,11 @@ await client.sendTransaction([myInstruction]);
 
 ## Client API Surface
 
-After applying an all-in-one RPC/LiteSVM plugin and a payer:
+See [overview.md](overview.md#client-api) for the full surface (`client.rpc`, `client.payer`, `client.sendTransaction`, etc.). Plugin-specific additions:
 
-```ts
-client.rpc                  // RPC methods (getBalance, getAccountInfo, etc.)
-client.rpcSubscriptions     // WebSocket subscriptions (RPC plugins only)
-client.payer                // TransactionSigner fee payer
-client.identity             // Authority signer (if signer()/identity() used)
-client.transactionPlanner   // Converts instructions → transaction messages
-client.transactionPlanExecutor // Sends planned transactions
-client.planTransaction(s)   // Plan without executing
-client.sendTransaction(s)   // Plan + sign + send in one call
-client.getMinimumBalance(dataSize) // Rent-exempt minimum
-```
-
-`solanaDevnetRpc`, `solanaLocalRpc`, and `litesvm` additionally expose:
-```ts
-client.airdrop(address, lamports) // Faucet (devnet/local/svm only)
-```
-
-LiteSVM additionally exposes `client.svm` for direct LiteSVM access.
+- `solanaDevnetRpc` / `solanaLocalRpc` / `litesvm` add `client.airdrop(address, lamports)`.
+- `litesvm` additionally adds `client.svm` for direct LiteSVM access.
+- The low-level composition (Custom Client Composition below) also exposes `client.transactionPlanner` and `client.transactionPlanExecutor` directly.
 
 ---
 

--- a/skill/references/kit/plugins.md
+++ b/skill/references/kit/plugins.md
@@ -67,11 +67,14 @@ npm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer
 ```
 
 ```ts
-import { createClient } from '@solana/kit';
+import { createClient, lamports } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
-import { signer } from '@solana/kit-plugin-signer';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 
-const client = createClient().use(signer(mySigner)).use(litesvm());
+const client = await createClient()
+  .use(generatedSigner())
+  .use(litesvm())
+  .use(airdropSigner(lamports(1_000_000_000n)));
 
 client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
@@ -111,18 +114,23 @@ In most apps both roles are the same keypair, so **default to the `signer*` vari
 |---|---|
 | `signer(s)` / `payer(s)` / `identity(s)` | Install an existing `TransactionSigner` |
 | `generatedSigner()` / `generatedPayer()` / `generatedIdentity()` | Async; generate a new keypair |
-| `generatedSignerWithSol(amount)` / `generatedPayerWithSol(amount)` / `generatedIdentityWithSol(amount)` | Async; generate + airdrop. Requires an airdrop function already on the client (use after `solanaLocalRpc`/`solanaDevnetRpc`/`rpcAirdrop`) |
+| `generatedSignerWithSol(amount)` / `generatedPayerWithSol(amount)` / `generatedIdentityWithSol(amount)` | Async; generate + airdrop. Requires an airdrop function already on the client (for low-level composition, install `rpcAirdrop()` first). |
 | `signerFromFile(path)` / `payerFromFile(path)` / `identityFromFile(path)` | Async; load keypair from a JSON file |
-| `airdropSigner(amount)` / `airdropPayer(amount)` / `airdropIdentity(amount)` | Airdrop SOL to an already-installed signer |
+| `airdropSigner(amount)` / `airdropPayer(amount)` / `airdropIdentity(amount)` | Airdrop SOL to an already-installed signer. Use with all-in-one `solanaLocalRpc` / `solanaDevnetRpc` / `litesvm` when the RPC plugin needs a payer first. |
 
 ```ts
 import { createClient, lamports } from '@solana/kit';
-import { rpcAirdrop, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+import {
+  rpcAirdrop,
+  solanaRpcConnection,
+  solanaRpcSubscriptionsConnection,
+} from '@solana/kit-plugin-rpc';
 import { generatedSignerWithSol } from '@solana/kit-plugin-signer';
 
 // Airdrop function must exist before generatedSignerWithSol
 const client = await createClient()
-  .use(solanaRpcConnection({ rpcUrl: 'http://127.0.0.1:8899' }))
+  .use(solanaRpcConnection('http://127.0.0.1:8899'))
+  .use(solanaRpcSubscriptionsConnection('ws://127.0.0.1:8900'))
   .use(rpcAirdrop())
   .use(generatedSignerWithSol(lamports(10_000_000_000n)));
 ```

--- a/skill/references/kit/plugins.md
+++ b/skill/references/kit/plugins.md
@@ -1,120 +1,186 @@
 ---
 title: Plugins & Client Composition
-description: Ready-to-use Solana Kit clients, plugin architecture, custom client composition, and available plugins from @solana/kit-client-rpc and the kit-plugins ecosystem.
+description: Solana Kit plugin architecture, all-in-one RPC/LiteSVM plugins, signer plugins, custom client composition, and plugin ordering rules.
 ---
 
 # Solana Kit Plugins & Client Composition
 
-## Ready-to-Use Clients
+Kit clients are built by chaining `.use(plugin)` calls onto `createClient()`. Each plugin extends the client with new properties or methods. Plugins that depend on others (e.g., RPC needs a payer) must come after their dependencies — TypeScript enforces this.
 
-### Production Client
+## All-in-One Clients
+
+### Production Client (mainnet/devnet/custom)
 
 ```bash
-npm install @solana/kit @solana/kit-client-rpc
+npm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer
 ```
 
 ```ts
-import { generateKeyPairSigner } from '@solana/kit';
-import { createClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaRpc } from '@solana/kit-plugin-rpc';
+import { signer } from '@solana/kit-plugin-signer';
 
-const payer = await generateKeyPairSigner();
-const client = createClient({
-  url: 'https://api.devnet.solana.com',
-  payer,
-});
+const client = createClient()
+  .use(signer(mySigner)) // sets payer + identity to the same keypair
+  .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 
 await client.sendTransaction([myInstruction]);
 ```
 
-**Config options:**
+`solanaRpc` installs an RPC connection, RPC subscriptions, minimum-balance computation, transaction planner, and transaction executor in one call. It requires a `payer` to be set first — `signer()` covers that and the identity role at the same time. Reach for the role-specific `payer()` + `identity()` only when fees and authority must come from different keypairs.
+
+**`solanaRpc` options:**
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `url` | `string` | RPC endpoint (required) |
-| `payer` | `TransactionSigner` | Fee payer (required) |
-| `rpcSubscriptionsConfig` | `object` | WebSocket endpoint config |
-| `priorityFees` | `MicroLamports` | Per-compute-unit fee boost |
+| `rpcUrl` | `string` | RPC endpoint (required) |
+| `rpcSubscriptionsUrl` | `string` | WS endpoint (defaults to `rpcUrl` with `http`→`ws`) |
+| `rpcConfig` | `object` | Forwarded to `createSolanaRpc` |
+| `rpcSubscriptionsConfig` | `object` | Forwarded to `createSolanaRpcSubscriptions` |
+| `transactionConfig` | `object` | Tx planner options (priority fees, etc.) |
 | `maxConcurrency` | `number` | Concurrent tx limit (default: 10) |
-| `skipPreflight` | `boolean` | Bypass simulation (default: false) |
+| `skipPreflight` | `boolean` | Always skip preflight (default: false) |
 
-### Local Development Client
+### Cluster-Specialized Variants
 
 ```ts
-import { createLocalClient } from '@solana/kit-client-rpc';
-import { lamports } from '@solana/kit';
+import { createClient } from '@solana/kit';
+import { solanaMainnetRpc, solanaDevnetRpc, solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { signer, signerFromFile } from '@solana/kit-plugin-signer';
 
-const client = await createLocalClient();
+// Mainnet — type-narrowed; airdrop is NOT exposed
+const main = createClient().use(signer(s)).use(solanaMainnetRpc({ rpcUrl: '...' }));
 
-// Payer auto-generated and funded
-console.log('Payer:', client.payer.address);
-await client.sendTransaction([myInstruction]);
+// Devnet — defaults to https://api.devnet.solana.com, includes airdrop
+const dev = createClient().use(signer(s)).use(solanaDevnetRpc());
 
-// Request more SOL
-await client.airdrop(client.payer.address, lamports(5_000_000_000n));
+// Local — defaults to http://127.0.0.1:8899, includes airdrop
+const local = await createClient()
+  .use(signerFromFile('~/.config/solana/id.json'))
+  .use(solanaLocalRpc());
 ```
-
-Defaults to `http://127.0.0.1:8899`. Accepts optional `payer`, `url`, and same config as `createClient`.
 
 ### LiteSVM Test Client
 
 ```bash
-npm install @solana/kit @solana/kit-client-litesvm
+npm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer
 ```
 
 ```ts
-import { createClient } from '@solana/kit-client-litesvm';
+import { createClient } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { signer } from '@solana/kit-plugin-signer';
 
-const client = await createClient();
+const client = createClient().use(signer(mySigner)).use(litesvm());
 
-// Set up test environment
 client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 
 await client.sendTransaction([myInstruction]);
 ```
 
+`litesvm()` is Node.js only. Browser/React Native builds throw.
+
 ---
 
 ## Client API Surface
 
-All plugin clients expose:
+After applying an all-in-one RPC/LiteSVM plugin and a payer:
 
 ```ts
 client.rpc                  // RPC methods (getBalance, getAccountInfo, etc.)
-client.rpcSubscriptions     // WebSocket subscriptions
+client.rpcSubscriptions     // WebSocket subscriptions (RPC plugins only)
 client.payer                // TransactionSigner fee payer
+client.identity             // Authority signer (if signer()/identity() used)
 client.transactionPlanner   // Converts instructions → transaction messages
 client.transactionPlanExecutor // Sends planned transactions
 client.planTransaction(s)   // Plan without executing
 client.sendTransaction(s)   // Plan + sign + send in one call
+client.getMinimumBalance(dataSize) // Rent-exempt minimum
 ```
 
-`createLocalClient` additionally provides:
+`solanaDevnetRpc`, `solanaLocalRpc`, and `litesvm` additionally expose:
 ```ts
-client.airdrop(address, amount) // Request SOL from faucet
+client.airdrop(address, lamports) // Faucet (devnet/local/svm only)
+```
+
+LiteSVM additionally exposes `client.svm` for direct LiteSVM access.
+
+---
+
+## Signer Plugins (`@solana/kit-plugin-signer`)
+
+Kit clients hold two signer roles:
+- **`payer`** — pays fees and rent
+- **`identity`** — wallet/authority for application accounts
+
+In most apps both roles are the same keypair, so **default to the `signer*` variants** — they install one keypair into both slots in one call. Use the role-specific `payer*` / `identity*` variants only when fees and authority come from different keypairs (e.g., gasless flows, treasury accounts, multisig).
+
+| Variant | Sets |
+|---|---|
+| `signer*` (recommended default) | both `payer` and `identity` (same keypair) |
+| `payer*` | only `payer` |
+| `identity*` | only `identity` |
+
+| Plugin | Behavior |
+|---|---|
+| `signer(s)` / `payer(s)` / `identity(s)` | Install an existing `TransactionSigner` |
+| `generatedSigner()` / `generatedPayer()` / `generatedIdentity()` | Async; generate a new keypair |
+| `generatedSignerWithSol(amount)` / `generatedPayerWithSol(amount)` / `generatedIdentityWithSol(amount)` | Async; generate + airdrop. Requires an airdrop function already on the client (use after `solanaLocalRpc`/`solanaDevnetRpc`/`rpcAirdrop`) |
+| `signerFromFile(path)` / `payerFromFile(path)` / `identityFromFile(path)` | Async; load keypair from a JSON file |
+| `airdropSigner(amount)` / `airdropPayer(amount)` / `airdropIdentity(amount)` | Airdrop SOL to an already-installed signer |
+
+```ts
+import { createClient, lamports } from '@solana/kit';
+import { rpcAirdrop, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+import { generatedSignerWithSol } from '@solana/kit-plugin-signer';
+
+// Airdrop function must exist before generatedSignerWithSol
+const client = await createClient()
+  .use(solanaRpcConnection({ rpcUrl: 'http://127.0.0.1:8899' }))
+  .use(rpcAirdrop())
+  .use(generatedSignerWithSol(lamports(10_000_000_000n)));
+```
+
+**Role-split example** (different keypairs for fees vs. authority):
+
+```ts
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { payer, identity } from '@solana/kit-plugin-signer';
+
+const client = createClient()
+  .use(payer(feePayerSigner))      // pays fees
+  .use(identity(walletSigner))     // owns/authorizes accounts
+  .use(solanaDevnetRpc());
 ```
 
 ---
 
 ## Custom Client Composition
 
-When the ready-to-use clients don't fit your needs, build your own with `createEmptyClient().use(...)`:
+When the all-in-one bundles don't fit (custom transaction planner, partial capabilities, third-party services), build the client out of low-level plugins:
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
-import { rpc } from '@solana/kit-plugin-rpc';
-import { payerFromFile } from '@solana/kit-plugin-payer';
-import { airdrop } from '@solana/kit-plugin-airdrop';
-import { rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
+import { createClient } from '@solana/kit';
+import {
+  rpc,
+  rpcAirdrop,
+  rpcGetMinimumBalance,
+  rpcTransactionPlanner,
+  rpcTransactionPlanExecutor,
+} from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
-const client = await createEmptyClient()
-  .use(rpc('https://api.devnet.solana.com'))       // Adds client.rpc + client.rpcSubscriptions
-  .use(payerFromFile('path/to/keypair.json'))       // Adds client.payer from local file
-  .use(airdrop())                                    // Adds client.airdrop
-  .use(rpcTransactionPlanner())                      // Adds client.transactionPlanner
-  .use(rpcTransactionPlanExecutor())                 // Adds client.transactionPlanExecutor
-  .use(planAndSendTransactions());                   // Adds client.sendTransaction(s)
+const client = await createClient()
+  .use(rpc('https://api.devnet.solana.com'))    // adds client.rpc + client.rpcSubscriptions
+  .use(signerFromFile('path/to/keypair.json'))  // adds client.payer + client.identity
+  .use(rpcAirdrop())                             // adds client.airdrop
+  .use(rpcGetMinimumBalance())                   // adds client.getMinimumBalance
+  .use(rpcTransactionPlanner())                  // adds client.transactionPlanner
+  .use(rpcTransactionPlanExecutor())             // adds client.transactionPlanExecutor
+  .use(planAndSendTransactions());               // adds client.sendTransaction(s)
 ```
 
 ### Plugin Ordering
@@ -122,53 +188,57 @@ const client = await createEmptyClient()
 Plugins that depend on others must come after their dependencies. TypeScript enforces this:
 
 ```ts
-// ✅ Correct — rpc before payer
-createEmptyClient()
+// ✅ Correct — signer + rpc before planner/executor
+createClient()
+  .use(signer(mySigner))
   .use(rpc(url))
-  .use(payer(signer))
   .use(rpcTransactionPlanner())
   .use(planAndSendTransactions());
 
-// ❌ Type error — planner requires rpc
-createEmptyClient()
-  .use(rpcTransactionPlanner())
-  .use(rpc(url));
+// ❌ Type error — solanaRpc requires payer
+createClient()
+  .use(solanaRpc({ rpcUrl: url }))
+  .use(signer(mySigner));
 ```
 
 ### Async Plugins
 
-Some plugins are async (e.g., `payerFromFile`, `generatedPayer`). The `use` method handles awaiting automatically — just `await` the final client:
+Some plugins are async (e.g., `signerFromFile`, `generatedSigner`, `generatedSignerWithSol`). The `.use()` method handles awaiting automatically — `await` the final client:
 
 ```ts
-const client = await createEmptyClient()
-  .use(rpc(url))
-  .use(payerFromFile('./keypair.json'))  // async
-  .use(rpcTransactionPlanner());
+const client = await createClient()
+  .use(signerFromFile('./keypair.json'))        // async
+  .use(solanaLocalRpc());
 ```
 
 ---
 
-## Available Plugins
+## Plugin Catalog
 
 ### Official Plugins
 
 | Package | Plugins | Purpose |
 |---------|---------|---------|
-| `@solana/kit-plugin-rpc` | `rpc`, `localhostRpc`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor` | RPC connectivity + tx execution |
-| `@solana/kit-plugin-payer` | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`, `payerOrGeneratedPayer` | Fee payer management |
-| `@solana/kit-plugin-airdrop` | `airdrop`, `rpcAirdrop` | SOL faucet requests |
-| `@solana/kit-plugin-instruction-plan` | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions` | Instruction batching + sending |
-| `@solana/kit-plugin-litesvm` | `litesvm`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor` | In-memory test environment |
+| `@solana/kit-plugin-rpc` | `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc`, `rpc`, `solanaRpcConnection`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor` | RPC connectivity + tx planning/execution |
+| `@solana/kit-plugin-signer` | `signer*` (default — sets both roles), `payer*`, `identity*` (role-specific); each comes in plain, `generated*`, `*WithSol`, `*FromFile`, and `airdrop*` forms | Signer management |
+| `@solana/kit-plugin-litesvm` | `litesvm`, `litesvmConnection`, `litesvmAirdrop`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor` | In-memory test environment |
+| `@solana/kit-plugin-airdrop` | `airdrop`, `rpcAirdrop` | SOL faucet (typically pulled in transitively) |
+| `@solana/kit-plugin-instruction-plan` | `planAndSendTransactions` | Instruction batching + sending sugar |
 
 ### Program Plugins
 
 Codama-generated `@solana-program/*` packages also export program plugins that attach fluent APIs to the client:
 
 ```ts
-import { createLocalClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
 import { tokenProgram } from '@solana-program/token';
 
-const client = await createLocalClient().use(tokenProgram());
+const client = await createClient()
+  .use(signerFromFile('~/.config/solana/id.json'))
+  .use(solanaLocalRpc())
+  .use(tokenProgram());
 
 // Fluent API — auto-derives ATAs, defaults payer from client
 await client.token.instructions
@@ -180,17 +250,11 @@ await client.token.instructions
 |---------|--------|------|
 | `@solana-program/token` | `tokenProgram()` | `client.token.instructions` (createMint, mintToATA, transferToATA, etc.) |
 
-### Pre-Configured Client Packages
+### Example Implementations
 
-| Package | Exports | Purpose |
-|---------|---------|---------|
-| `@solana/kit-client-rpc` | `createClient`, `createLocalClient` | Production & local dev |
-| `@solana/kit-client-litesvm` | `createClient` | LiteSVM testing |
-
-### Example Implmentations
-
-| Package | Exports | Purpose | Code Example | 
-| `@solana/kora` | `createKitKoraClient`, `koraPlugin` | Gasless Transactions |  https://github.com/solana-foundation/kora/blob/main/sdks/ts/src/kit/index.ts |
+| Package | Exports | Purpose | Code Example |
+|---------|---------|---------|--------------|
+| `@solana/kora` | `createKitKoraClient`, `koraPlugin` | Gasless transactions | https://github.com/solana-foundation/kora/blob/main/sdks/ts/src/kit/index.ts |
 
 ---
 
@@ -215,8 +279,7 @@ function myCustomPlugin() {
   });
 }
 
-// Use it
-const client = createEmptyClient().use(myCustomPlugin());
+const client = createClient().use(myCustomPlugin());
 client.myMethod(); // 'hello'
 ```
 
@@ -231,8 +294,8 @@ function myRpcPlugin() {
 }
 
 // ✅ Works — rpc installed first
-createEmptyClient().use(rpc(url)).use(myRpcPlugin());
+createClient().use(rpc(url)).use(myRpcPlugin());
 
 // ❌ Type error — rpc not present
-createEmptyClient().use(myRpcPlugin());
+createClient().use(myRpcPlugin());
 ```

--- a/skill/references/kit/programs/compute-budget.md
+++ b/skill/references/kit/programs/compute-budget.md
@@ -17,7 +17,7 @@ Correctly budgeting compute units for your transaction increases the probability
 
 ### Set Compute Unit Limit
 
-If you're using `createClient`/`createLocalClient` from `@solana/kit-client-rpc`, CU estimation is handled automatically via `sendTransaction()` — you don't need this. Use the manual instructions below when building transactions with `pipe()` or when you need direct control. See [overview.md](../overview.md) and [plugins.md](../plugins.md).
+If you're using a Kit client built with the `solanaRpc` / `solanaLocalRpc` / `solanaDevnetRpc` / `solanaMainnetRpc` plugins (from `@solana/kit-plugin-rpc`), CU estimation is handled automatically via `client.sendTransaction()` — you don't need this. Use the manual instructions below when building transactions with `pipe()` or when you need direct control. See [overview.md](../overview.md) and [plugins.md](../plugins.md).
 
 Always set based on simulation — overestimate wastes block space, underestimate fails the transaction.
 


### PR DESCRIPTION
Updates Kit references based on 6.8 (client deprecations, full migration to plugins)

- Updates `skill/references/kit/` to the current `@solana/kit` API: `createClient()` from `@solana/kit` + `.use()` plugins from `@solana/kit-plugin-rpc` / `@solana/kit-plugin-signer` / `@solana/kit-plugin-litesvm`.
- Removes all references to deprecated packages (`@solana/kit-client-rpc`, `@solana/kit-client-litesvm`, `@solana/kit-plugin-payer`) and to `createEmptyClient` / `createLocalClient`.
- Promotes `signer*` variants (sets both payer + identity) as the default; documents `payer*` / `identity*` as the role-split path.
- Trims duplication: `solanaRpc` options table lives only in `plugins.md`; client API surface lives only in `overview.md`.
