### PR TITLE
chore(skill): unify solanaRpcConnection example for kit-plugin-rpc 0.11

### DIFF
--- a/skill/references/kit/plugins.md
+++ b/skill/references/kit/plugins.md
@@ -120,17 +120,14 @@ In most apps both roles are the same keypair, so **default to the `signer*` vari
 
 ```ts
 import { createClient, lamports } from '@solana/kit';
-import {
-  rpcAirdrop,
-  solanaRpcConnection,
-  solanaRpcSubscriptionsConnection,
-} from '@solana/kit-plugin-rpc';
+import { rpcAirdrop, solanaRpcConnection } from '@solana/kit-plugin-rpc';
 import { generatedSignerWithSol } from '@solana/kit-plugin-signer';
 
-// Airdrop function must exist before generatedSignerWithSol
+// `solanaRpcConnection` installs both `rpc` and `rpcSubscriptions`; the WS URL
+// is derived from `rpcUrl` (override with `rpcSubscriptionsUrl` if needed).
+// Airdrop function must exist before generatedSignerWithSol.
 const client = await createClient()
-  .use(solanaRpcConnection('http://127.0.0.1:8899'))
-  .use(solanaRpcSubscriptionsConnection('ws://127.0.0.1:8900'))
+  .use(solanaRpcConnection({ rpcUrl: 'http://127.0.0.1:8899' }))
   .use(rpcAirdrop())
   .use(generatedSignerWithSol(lamports(10_000_000_000n)));
 ```


### PR DESCRIPTION
## Summary
- Collapse the dual `solanaRpcConnection(url)` + `solanaRpcSubscriptionsConnection(wsUrl)` example in `skill/references/kit/plugins.md` into the unified `solanaRpcConnection({ rpcUrl })` form shipped in `@solana/kit-plugin-rpc@0.11`.
- WS URL is now auto-derived from `rpcUrl` (override via `rpcSubscriptionsUrl`); `solanaRpcSubscriptionsConnection` is soft-deprecated upstream ([anza-xyz/kit-plugins#203](https://github.com/anza-xyz/kit-plugins/pull/203)).
- Verified repo-wide: no remaining references to soft-deprecated `solanaRpcSubscriptionsConnection` / `rpcConnection` / `rpcSubscriptionsConnection`. `SKILL.md` already only uses the all-in-one `solanaRpc({ rpcUrl })`, which is unaffected.

Closes [DEV-487](https://linear.app/solana-fndn/issue/DEV-487/solana-dev-skill-update-kitplugins-references-for-solanarpcconnection). Parent: DEV-477.

## Test plan
- [x] grep for soft-deprecated names under `skill/` returns empty
- [x] Snippet matches 0.11 plugin signature (`{ rpcUrl }` options form, plugin order preserved)