### PR TITLE
docs(kit): fix broken instruction-plan and assertion examples in solana-dev skill

### DIFF
--- a/skills/solana-dev/references/kit/gotchas.md
+++ b/skills/solana-dev/references/kit/gotchas.md
@@ -64,9 +64,9 @@ import type { Instruction } from '@solana/kit';
 **Cause:** Trying to send unsigned message (manual pipeline only).
 
 ```ts
-// ✅ Fix: Assert fully signed
-import { assertTransactionMessageIsFullySigned } from '@solana/transaction-messages';
-assertTransactionMessageIsFullySigned(message);
+// ✅ Fix: Assert the signed transaction is fully signed
+import { assertIsFullySignedTransaction } from '@solana/transactions';
+assertIsFullySignedTransaction(signedTransaction);
 ```
 
 ### "Missing blockhash lifetime"
@@ -75,8 +75,8 @@ assertTransactionMessageIsFullySigned(message);
 
 ```ts
 // ✅ Fix: Assert lifetime exists
-import { assertTransactionMessageHasBlockhashLifetime } from '@solana/transaction-messages';
-assertTransactionMessageHasBlockhashLifetime(message);
+import { assertIsTransactionMessageWithBlockhashLifetime } from '@solana/transaction-messages';
+assertIsTransactionMessageWithBlockhashLifetime(message);
 ```
 
 ### `signAndSendTransactionMessageWithSigners` type error
@@ -197,8 +197,8 @@ if (!account.exists) {
 | Plugin ordering type error | Install dependencies before dependents (`signer()` before `solanaRpc`/`litesvm`) |
 | Forgot to `await` async client | `const client = await createClient().use(signerFromFile(...)).use(solanaLocalRpc())` |
 | `IInstruction` doesn't exist | Use `Instruction` from `@solana/kit` |
-| "Transaction message must be signed" | `assertTransactionMessageIsFullySigned(msg)` |
-| "Missing blockhash lifetime" | `assertTransactionMessageHasBlockhashLifetime(msg)` |
+| "Transaction message must be signed" | `assertIsFullySignedTransaction(signedTx)` |
+| "Missing blockhash lifetime" | `assertIsTransactionMessageWithBlockhashLifetime(msg)` |
 | Blockhash expired after CU estimation | Refresh blockhash AFTER `estimateAndUpdateCU()` |
 | `signAndSendTransactionMessageWithSigners` type error | Use `setTransactionMessageFeePayerSigner` (not address) |
 | Account doesn't exist runtime error | `assertAccountExists(account)` before decode |

--- a/skills/solana-dev/references/kit/programs/token.md
+++ b/skills/solana-dev/references/kit/programs/token.md
@@ -140,7 +140,7 @@ const ix = getBurnInstruction({
 
 ## Instruction Plans
 
-Handle multi-step operations (e.g., create ATA if needed). Auto-check preconditions and only include necessary instructions — use for user-facing flows. Build a plan with the `get*InstructionPlan` builders, then execute it through a plugin client that has planning + sending capability via `client.sendTransaction(plan)` (see [plugins.md](../plugins.md)). For a shorter form, `client.use(tokenProgram())` exposes `client.token.createMint(...)` / `client.token.mintToATA(...)`, which build and send in one call.
+Handle multi-step operations (e.g., create ATA if needed). Auto-check preconditions and only include necessary instructions — use for user-facing flows. Build a plan with the `get*InstructionPlan` builders, then execute it through a plugin client that has planning + sending capability via `client.sendTransaction(plan)` (see [plugins.md](../plugins.md)). For a shorter form, `client.use(tokenProgram())` exposes `client.token.instructions.createMint(...)` / `client.token.instructions.mintToATA(...)`; call `.sendTransaction()` on the returned plan to submit (e.g. `await client.token.instructions.createMint({ newMint, decimals, mintAuthority }).sendTransaction()`).
 
 ### Create Mint
 

--- a/skills/solana-dev/references/kit/programs/token.md
+++ b/skills/solana-dev/references/kit/programs/token.md
@@ -140,40 +140,40 @@ const ix = getBurnInstruction({
 
 ## Instruction Plans
 
-Handle multi-step operations (e.g., create ATA if needed). Auto-check preconditions and only include necessary instructions — use for user-facing flows.
+Handle multi-step operations (e.g., create ATA if needed). Auto-check preconditions and only include necessary instructions — use for user-facing flows. Build a plan with the `get*InstructionPlan` builders, then execute it through a plugin client that has planning + sending capability via `client.sendTransaction(plan)` (see [plugins.md](../plugins.md)). For a shorter form, `client.use(tokenProgram())` exposes `client.token.createMint(...)` / `client.token.mintToATA(...)`, which build and send in one call.
 
 ### Create Mint
 
 ```ts
 import { getCreateMintInstructionPlan } from '@solana-program/token';
-import { executeInstructionPlan } from '@solana/instruction-plans';
 
 const plan = getCreateMintInstructionPlan({
-  mint: mintKeypair,
+  payer,
+  newMint: mintKeypair,
   decimals: 9,
   mintAuthority: authority.address,
-  payer,
-  rpc,
 });
 
-await executeInstructionPlan(rpc, plan, { payer });
+await client.sendTransaction(plan);
 ```
 
 ### Mint to ATA (Creates ATA if needed)
 
-```ts
-import { getMintToATAInstructionPlan } from '@solana-program/token';
+Use the async builder — it derives the ATA automatically.
 
-const plan = getMintToATAInstructionPlan({
+```ts
+import { getMintToATAInstructionPlanAsync } from '@solana-program/token';
+
+const plan = await getMintToATAInstructionPlanAsync({
+  payer,
+  owner: recipientAddress,
   mint: mintAddress,
   mintAuthority: authority,
-  owner: recipientAddress,
   amount: 1_000_000_000n,
-  payer,
-  rpc,
+  decimals: 9,
 });
 
-await executeInstructionPlan(rpc, plan, { payer });
+await client.sendTransaction(plan);
 ```
 
 ## Complete Pattern: Create Token + Mint


### PR DESCRIPTION
## Summary
Fixes two sets of copy-paste-broken examples in the `solana-dev` kit reference.

**Instruction plans (`token.md`)**
- Replace non-existent `executeInstructionPlan` import with `client.sendTransaction(plan)` execution via the plugin client
- Fix `getCreateMintInstructionPlan` inputs (`newMint` instead of `mint`, drop bogus `rpc` field)
- Switch Mint-to-ATA to `getMintToATAInstructionPlanAsync` (auto-derives the ATA) with required `decimals`

**Assertion exports (`gotchas.md`)**
- `assertTransactionMessageIsFullySigned` → `assertIsFullySignedTransaction` (`@solana/transactions`)
- `assertTransactionMessageHasBlockhashLifetime` → `assertIsTransactionMessageWithBlockhashLifetime` (`@solana/transaction-messages`)
- Update the quick-reference table entries to match

## Test Plan
- Instruction-plan examples: `tsc --noEmit` in a Bun project against `@solana/kit@7.0.0` + `@solana-program/token@0.14.0` — passes
- Assertion exports: verified both names resolve as functions from their subpackages at kit 7.0.0

Closes DEV-762
Closes DEV-761